### PR TITLE
feat: provide dedicated exports for styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     },
+    "./css": "./dist/style/siemens-element-icons.css",
+    "./min-css": "./dist/style/siemens-element-icons.min.css",
+    "./scss": "./dist/style/siemens-element-icons.scss",
+    "./variables-scss": "./dist/style/variables.scss",
     "./*": {
       "default": "./dist/*"
     },


### PR DESCRIPTION
Allows using stylesheets without deep imports:
```scss
@use '@siemens/element-icons/css';
@use '@siemens/element-icons/min-css';
@use '@siemens/element-icons/scss';
@use '@siemens/element-icons/variables-scss';
```