### PR TITLE
fix: add icon and drawio zip files to the release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -61,7 +61,11 @@ export default {
     [
       '@semantic-release/github',
       {
-        successComment: false
+        successComment: false,
+        assets: [
+          { path: 'dist/siemens-element-icons.zip' },
+          { path: 'dist/siemens-element-icons-drawio.zip' }
+        ]
       }
     ]
   ]


### PR DESCRIPTION
Internally, we had only the latest published to the docs pages. But adding them as artifacts to the release is a better approach in my opinion.