### PR TITLE
fix: allow npm package to be installed with any engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "type": "module",
   "engines": {
     "node": "^24.0.0",
-    "yarn": "Please use NPM to install dependencies",
     "npm": "11"
   },
   "prettier": "@siemens/prettier-config",


### PR DESCRIPTION
currently it is not possible to install this package if application is using yarn engine.
