### PR TITLE
build(lint-metadata): fix mode + remove inner-source icons

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
       - run: npm ci --prefer-offline --no-audit
       - run: npm run lint
       - run: npm run lint:format
+      - run: npm run lint:metadata
       - run: npm run build
       - uses: actions/upload-artifact@v6
         with:

--- a/lint-metadata.js
+++ b/lint-metadata.js
@@ -3,24 +3,111 @@
  * SPDX-License-Identifier: MIT
  */
 import fs from 'fs';
+import path from 'path';
 
 const ICON_PATH = 'assets/icons';
 const METADATA_PATH = 'src/element-icon-metadata.json';
+const fix = process.argv.includes('--fix');
 
-const icons = fs
-  .readdirSync(ICON_PATH)
-  .filter(i => i.endsWith('.svg'))
-  .map(i => i.substring(0, i.length - 4));
-const metadata = JSON.parse(fs.readFileSync(METADATA_PATH, 'utf8')).map(m => m.name);
+function readIconsFromFs() {
+  return fs
+    .readdirSync(ICON_PATH)
+    .filter(f => f.endsWith('.svg'))
+    .map(f => f.slice(0, -4));
+}
 
-const missingFiles = metadata.filter(icon => !icons.includes(icon));
-if (missingFiles.length > 0) {
-  console.error(`Icons "${missingFiles.join('", "')}" are referenced but don't exist.`);
+function readMetadata() {
+  return JSON.parse(fs.readFileSync(METADATA_PATH, 'utf8'));
+}
+
+/**
+ * Validates that every icon referenced in metadata has a corresponding SVG file.
+ * Fix: removes stale metadata entries.
+ * @returns {object[]} updated metadata
+ */
+function validateMetadataIconsExistInFs(icons, metadata) {
+  const iconSet = new Set(icons);
+  const missing = metadata.map(m => m.name).filter(name => !iconSet.has(name));
+  if (missing.length === 0) return metadata;
+
+  if (fix) {
+    console.log(
+      `Fixing: removing ${missing.length} metadata entr${missing.length === 1 ? 'y' : 'ies'} for non-existent icon${missing.length === 1 ? '' : 's'}: "${missing.join('", "')}"`
+    );
+    const missingSet = new Set(missing);
+    return metadata.filter(m => !missingSet.has(m.name));
+  }
+
+  console.error(
+    `Icons "${missing.join('", "')}" are referenced in metadata but don't exist in the file system.`
+  );
   process.exit(1);
 }
 
-const missingReferences = icons.filter(icon => !metadata.includes(icon));
-if (missingReferences.length > 0) {
-  console.error(`Icons "${missingReferences.join('", "')}" exist but are never referenced.`);
+/**
+ * Validates that every SVG file in the icons directory has a metadata entry.
+ * Fix: deletes orphaned SVG files.
+ * @returns {string[]} updated icons list
+ */
+function validateFsIconsExistInMetadata(icons, metadata) {
+  const metadataNames = new Set(metadata.map(m => m.name));
+  const orphaned = icons.filter(name => !metadataNames.has(name));
+  if (orphaned.length === 0) return icons;
+
+  if (fix) {
+    console.log(
+      `Fixing: deleting ${orphaned.length} icon file${orphaned.length === 1 ? '' : 's'} with no metadata entry: "${orphaned.join('", "')}"`
+    );
+    for (const name of orphaned) {
+      fs.rmSync(path.join(ICON_PATH, `${name}.svg`));
+    }
+    const orphanedSet = new Set(orphaned);
+    return icons.filter(name => !orphanedSet.has(name));
+  }
+
+  console.error(
+    `Icons "${orphaned.join('", "')}" exist in the file system but have no metadata entry.`
+  );
   process.exit(1);
+}
+
+/**
+ * Validates that no icon is flagged as innerSource.
+ * Fix: removes innerSource metadata entries and deletes their SVG files.
+ * @returns {object[]} updated metadata
+ */
+function validateNoInnerSourceIcons(icons, metadata) {
+  const innerSource = metadata.filter(m => m.innerSource);
+  if (innerSource.length === 0) return metadata;
+
+  const names = innerSource.map(m => m.name);
+
+  if (fix) {
+    console.log(
+      `Fixing: removing ${innerSource.length} inner-source icon${innerSource.length === 1 ? '' : 's'}: "${names.join('", "')}"`
+    );
+    const iconSet = new Set(icons);
+    for (const name of names) {
+      if (iconSet.has(name)) {
+        fs.rmSync(path.join(ICON_PATH, `${name}.svg`));
+      }
+    }
+    return metadata.filter(m => !m.innerSource);
+  }
+
+  console.error(
+    `Icons "${names.join('", "')}" are flagged as inner-source and must not be included.`
+  );
+  process.exit(1);
+}
+
+let icons = readIconsFromFs();
+let metadata = readMetadata();
+
+metadata = validateMetadataIconsExistInFs(icons, metadata);
+icons = validateFsIconsExistInMetadata(icons, metadata);
+metadata = validateNoInnerSourceIcons(icons, metadata);
+
+if (fix) {
+  fs.writeFileSync(METADATA_PATH, JSON.stringify(metadata));
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "codepoints": "node codepoints.js",
     "format": "prettier --log-level warn --write .",
     "lint:format": "prettier --check .",
+    "lint:metadata": "node lint-metadata.js",
     "lint": "eslint ."
   },
   "exports": {

--- a/src/element-icon-metadata.json
+++ b/src/element-icon-metadata.json
@@ -1,9 +1,5 @@
 [
-  {
-    "name": "ai",
-    "terms": ["artificial intelligence"],
-    "category": "AI"
-  },
+  { "name": "ai", "terms": ["artificial intelligence"], "category": "AI" },
   {
     "name": "bot",
     "terms": [
@@ -21,46 +17,18 @@
     "terms": ["ai", "artificial intelligence", "virtual assistant"],
     "category": "AI"
   },
-  {
-    "name": "ai-message",
-    "terms": ["artificial intelligence", "chat"],
-    "category": "AI"
-  },
-  {
-    "name": "generate",
-    "terms": ["produce", "create"],
-    "category": "AI"
-  },
-  {
-    "name": "ai-code",
-    "terms": ["artificial intelligence", "code"],
-    "category": "AI"
-  },
+  { "name": "ai-message", "terms": ["artificial intelligence", "chat"], "category": "AI" },
+  { "name": "generate", "terms": ["produce", "create"], "category": "AI" },
+  { "name": "ai-code", "terms": ["artificial intelligence", "code"], "category": "AI" },
   {
     "name": "ai-audio-wave",
     "terms": ["artificial intelligence", "audio", "sound"],
     "category": "AI"
   },
-  {
-    "name": "ai-support",
-    "terms": ["artificial intelligence", "support"],
-    "category": "AI"
-  },
-  {
-    "name": "ai-optimize",
-    "terms": ["artificial intelligence", "optimize"],
-    "category": "AI"
-  },
-  {
-    "name": "ai-alt",
-    "terms": ["artificial intelligence"],
-    "category": "AI"
-  },
-  {
-    "name": "self-learning",
-    "terms": ["machine learning", "deep learning"],
-    "category": "AI"
-  },
+  { "name": "ai-support", "terms": ["artificial intelligence", "support"], "category": "AI" },
+  { "name": "ai-optimize", "terms": ["artificial intelligence", "optimize"], "category": "AI" },
+  { "name": "ai-alt", "terms": ["artificial intelligence"], "category": "AI" },
+  { "name": "self-learning", "terms": ["machine learning", "deep learning"], "category": "AI" },
   {
     "name": "temperature",
     "description": "",
@@ -82,188 +50,48 @@
     "terms": ["degree", "thermometer", "external temperature"],
     "category": "HVAC"
   },
-  {
-    "name": "boost-heating",
-    "terms": ["thermometer"],
-    "category": "HVAC"
-  },
-  {
-    "name": "boost-cooling",
-    "terms": ["thermometer"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-boost",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-alt",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-boost-alt",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "cooling",
-    "terms": ["air conditioning"],
-    "category": "HVAC"
-  },
-  {
-    "name": "producer",
-    "category": "HVAC"
-  },
-  {
-    "name": "burner",
-    "terms": ["heater"],
-    "category": "HVAC"
-  },
-  {
-    "name": "dhw",
-    "terms": ["domestic hot water"],
-    "category": "HVAC"
-  },
-  {
-    "name": "dhw-alt",
-    "terms": ["domestic hot water"],
-    "category": "HVAC"
-  },
-  {
-    "name": "humidity",
-    "terms": ["moisture"],
-    "category": "HVAC"
-  },
-  {
-    "name": "water",
-    "terms": ["liquid"],
-    "category": "HVAC"
-  },
-  {
-    "name": "humidity-indoor",
-    "terms": ["moisture"],
-    "category": "HVAC"
-  },
-  {
-    "name": "humidity-outdoor",
-    "terms": ["moisture"],
-    "category": "HVAC"
-  },
-  {
-    "name": "condensation-detection",
-    "terms": ["moisture", "humidity"],
-    "category": "HVAC"
-  },
+  { "name": "boost-heating", "terms": ["thermometer"], "category": "HVAC" },
+  { "name": "boost-cooling", "terms": ["thermometer"], "category": "HVAC" },
+  { "name": "fan", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-boost", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-alt", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-boost-alt", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "cooling", "terms": ["air conditioning"], "category": "HVAC" },
+  { "name": "producer", "category": "HVAC" },
+  { "name": "burner", "terms": ["heater"], "category": "HVAC" },
+  { "name": "dhw", "terms": ["domestic hot water"], "category": "HVAC" },
+  { "name": "dhw-alt", "terms": ["domestic hot water"], "category": "HVAC" },
+  { "name": "humidity", "terms": ["moisture"], "category": "HVAC" },
+  { "name": "water", "terms": ["liquid"], "category": "HVAC" },
+  { "name": "humidity-indoor", "terms": ["moisture"], "category": "HVAC" },
+  { "name": "humidity-outdoor", "terms": ["moisture"], "category": "HVAC" },
+  { "name": "condensation-detection", "terms": ["moisture", "humidity"], "category": "HVAC" },
   {
     "name": "waters",
     "terms": ["liquid", "lakes", "seas", "rivers", "ponds", "streams"],
     "category": "HVAC"
   },
-  {
-    "name": "steam",
-    "terms": ["vapor"],
-    "category": "HVAC"
-  },
-  {
-    "name": "blind",
-    "terms": ["shades", "drapes"],
-    "category": "HVAC"
-  },
-  {
-    "name": "slat-blind-angle",
-    "terms": ["slat"],
-    "category": "HVAC"
-  },
-  {
-    "name": "shutter",
-    "category": "HVAC"
-  },
-  {
-    "name": "awning",
-    "terms": ["shade", "sun blinds"],
-    "category": "HVAC"
-  },
-  {
-    "name": "curtain",
-    "category": "HVAC"
-  },
-  {
-    "name": "air",
-    "category": "HVAC"
-  },
-  {
-    "name": "outside-air",
-    "terms": ["external air"],
-    "category": "HVAC"
-  },
-  {
-    "name": "positive-pressure",
-    "category": "HVAC"
-  },
-  {
-    "name": "negative-pressure",
-    "category": "HVAC"
-  },
-  {
-    "name": "indoor-air-quality",
-    "terms": ["IAQ"],
-    "category": "HVAC"
-  },
-  {
-    "name": "outdoor-air-quality",
-    "terms": ["IAQ"],
-    "category": "HVAC"
-  },
-  {
-    "name": "co2",
-    "terms": ["carbon dioxide"],
-    "category": "HVAC"
-  },
-  {
-    "name": "co2-indoor",
-    "terms": ["carbon dioxide"],
-    "category": "HVAC"
-  },
-  {
-    "name": "co2-outdoor",
-    "terms": ["carbon dioxide"],
-    "category": "HVAC"
-  },
-  {
-    "name": "heat-cool-changeover",
-    "category": "HVAC"
-  },
-  {
-    "name": "operatingmode",
-    "terms": ["selector"],
-    "description": "",
-    "category": "HVAC"
-  },
-  {
-    "name": "operatingmode-alt",
-    "terms": ["selector"],
-    "category": "HVAC"
-  },
-  {
-    "name": "prolongation",
-    "terms": ["extension"],
-    "category": "HVAC"
-  },
-  {
-    "name": "optimum-start",
-    "category": "HVAC"
-  },
-  {
-    "name": "optimum-stop",
-    "category": "HVAC"
-  },
+  { "name": "steam", "terms": ["vapor"], "category": "HVAC" },
+  { "name": "blind", "terms": ["shades", "drapes"], "category": "HVAC" },
+  { "name": "slat-blind-angle", "terms": ["slat"], "category": "HVAC" },
+  { "name": "shutter", "category": "HVAC" },
+  { "name": "awning", "terms": ["shade", "sun blinds"], "category": "HVAC" },
+  { "name": "curtain", "category": "HVAC" },
+  { "name": "air", "category": "HVAC" },
+  { "name": "outside-air", "terms": ["external air"], "category": "HVAC" },
+  { "name": "positive-pressure", "category": "HVAC" },
+  { "name": "negative-pressure", "category": "HVAC" },
+  { "name": "indoor-air-quality", "terms": ["IAQ"], "category": "HVAC" },
+  { "name": "outdoor-air-quality", "terms": ["IAQ"], "category": "HVAC" },
+  { "name": "co2", "terms": ["carbon dioxide"], "category": "HVAC" },
+  { "name": "co2-indoor", "terms": ["carbon dioxide"], "category": "HVAC" },
+  { "name": "co2-outdoor", "terms": ["carbon dioxide"], "category": "HVAC" },
+  { "name": "heat-cool-changeover", "category": "HVAC" },
+  { "name": "operatingmode", "terms": ["selector"], "description": "", "category": "HVAC" },
+  { "name": "operatingmode-alt", "terms": ["selector"], "category": "HVAC" },
+  { "name": "prolongation", "terms": ["extension"], "category": "HVAC" },
+  { "name": "optimum-start", "category": "HVAC" },
+  { "name": "optimum-stop", "category": "HVAC" },
   {
     "name": "room-temperature-filled",
     "terms": ["degree", "thermometer", "internal temperature"],
@@ -274,228 +102,58 @@
     "terms": ["degree", "thermometer", "external temperature"],
     "category": "HVAC"
   },
-  {
-    "name": "dhw-filled",
-    "terms": ["domestic hot water"],
-    "category": "HVAC"
-  },
-  {
-    "name": "water-filled",
-    "terms": ["liquid"],
-    "category": "HVAC"
-  },
-  {
-    "name": "humidity-filled",
-    "terms": ["moisture"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-filled",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-boost-filled",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-alt-filled",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "fan-boost-alt-filled",
-    "terms": ["ventilator"],
-    "category": "HVAC"
-  },
-  {
-    "name": "prolongation-filled",
-    "terms": ["extension"],
-    "category": "HVAC"
-  },
-  {
-    "name": "shutter-filled",
-    "category": "HVAC"
-  },
-  {
-    "name": "awning-filled",
-    "terms": ["shade", "sun blinds"],
-    "category": "HVAC"
-  },
-  {
-    "name": "curtain-filled",
-    "category": "HVAC"
-  },
-  {
-    "name": "light",
-    "terms": ["light bulb", "idea"],
-    "category": "Light"
-  },
-  {
-    "name": "light-on",
-    "terms": ["light bulb", "idea"],
-    "category": "Light"
-  },
+  { "name": "dhw-filled", "terms": ["domestic hot water"], "category": "HVAC" },
+  { "name": "water-filled", "terms": ["liquid"], "category": "HVAC" },
+  { "name": "humidity-filled", "terms": ["moisture"], "category": "HVAC" },
+  { "name": "fan-filled", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-boost-filled", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-alt-filled", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "fan-boost-alt-filled", "terms": ["ventilator"], "category": "HVAC" },
+  { "name": "prolongation-filled", "terms": ["extension"], "category": "HVAC" },
+  { "name": "shutter-filled", "category": "HVAC" },
+  { "name": "awning-filled", "terms": ["shade", "sun blinds"], "category": "HVAC" },
+  { "name": "curtain-filled", "category": "HVAC" },
+  { "name": "light", "terms": ["light bulb", "idea"], "category": "Light" },
+  { "name": "light-on", "terms": ["light bulb", "idea"], "category": "Light" },
   { "name": "light-dimmable", "terms": ["light bulb", "dimming"], "category": "Light" },
   { "name": "light-on-dimmable", "terms": ["light bulb", "dimming"], "category": "Light" },
-  {
-    "name": "dim-up",
-    "terms": ["light bulb"],
-    "category": "Light"
-  },
-  {
-    "name": "dim-down",
-    "terms": ["light bulb"],
-    "category": "Light"
-  },
-  {
-    "name": "light-auto",
-    "terms": ["light bulb", "automation"],
-    "category": "Light"
-  },
-  {
-    "name": "light-rgb-bulb",
-    "terms": ["light color"],
-    "category": "Light"
-  },
-  {
-    "name": "light-color-temperature",
-    "terms": ["light color temperature"],
-    "category": "Light"
-  },
-  {
-    "name": "light-floor",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-desk",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-ceiling",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-wall",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-spot",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-ceiling-alt",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-down",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-rgb",
-    "terms": ["light color"],
-    "category": "Light"
-  },
-  {
-    "name": "light-flash",
-    "category": "Light"
-  },
-  {
-    "name": "light-filled",
-    "terms": ["light bulb", "idea"],
-    "category": "Light"
-  },
-  {
-    "name": "light-on-filled",
-    "terms": ["light bulb", "idea"],
-    "category": "Light"
-  },
+  { "name": "dim-up", "terms": ["light bulb"], "category": "Light" },
+  { "name": "dim-down", "terms": ["light bulb"], "category": "Light" },
+  { "name": "light-auto", "terms": ["light bulb", "automation"], "category": "Light" },
+  { "name": "light-rgb-bulb", "terms": ["light color"], "category": "Light" },
+  { "name": "light-color-temperature", "terms": ["light color temperature"], "category": "Light" },
+  { "name": "light-floor", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-desk", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-ceiling", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-wall", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-spot", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-ceiling-alt", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-down", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-rgb", "terms": ["light color"], "category": "Light" },
+  { "name": "light-flash", "category": "Light" },
+  { "name": "light-filled", "terms": ["light bulb", "idea"], "category": "Light" },
+  { "name": "light-on-filled", "terms": ["light bulb", "idea"], "category": "Light" },
   { "name": "light-dimmable-filled", "terms": ["light bulb", "dimming"], "category": "Light" },
   { "name": "light-on-dimmable-filled", "terms": ["light bulb", "dimming"], "category": "Light" },
-  {
-    "name": "dim-up-filled",
-    "terms": ["light bulb"],
-    "category": "Light"
-  },
-  {
-    "name": "dim-down-filled",
-    "terms": ["light bulb"],
-    "category": "Light"
-  },
-  {
-    "name": "light-auto-filled",
-    "terms": ["light bulb", "automation"],
-    "category": "Light"
-  },
-  {
-    "name": "light-rgb-bulb-filled",
-    "terms": ["light color"],
-    "category": "Light"
-  },
+  { "name": "dim-up-filled", "terms": ["light bulb"], "category": "Light" },
+  { "name": "dim-down-filled", "terms": ["light bulb"], "category": "Light" },
+  { "name": "light-auto-filled", "terms": ["light bulb", "automation"], "category": "Light" },
+  { "name": "light-rgb-bulb-filled", "terms": ["light color"], "category": "Light" },
   {
     "name": "light-color-temperature-filled",
     "terms": ["light color temperature"],
     "category": "Light"
   },
-  {
-    "name": "light-floor-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-desk-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-ceiling-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-wall-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-spot-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-ceiling-alt-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-down-filled",
-    "terms": ["lamp"],
-    "category": "Light"
-  },
-  {
-    "name": "light-rgb-filled",
-    "terms": ["light color"],
-    "category": "Light"
-  },
-  {
-    "name": "scenes",
-    "terms": ["movie clapper"],
-    "tags": ["scene"],
-    "category": "Scenes"
-  },
-  {
-    "name": "working",
-    "terms": ["office", "desk"],
-    "category": "Scenes"
-  },
+  { "name": "light-floor-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-desk-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-ceiling-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-wall-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-spot-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-ceiling-alt-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-down-filled", "terms": ["lamp"], "category": "Light" },
+  { "name": "light-rgb-filled", "terms": ["light color"], "category": "Light" },
+  { "name": "scenes", "terms": ["movie clapper"], "tags": ["scene"], "category": "Scenes" },
+  { "name": "working", "terms": ["office", "desk"], "category": "Scenes" },
   { "name": "desk", "terms": ["office"], "category": "Scenes" },
   { "name": "desk-booked", "terms": ["office", "desk"], "category": "Scenes" },
   {
@@ -503,108 +161,39 @@
     "terms": ["conference", "collaboration", "teamwork", "group"],
     "category": "Scenes"
   },
-  {
-    "name": "reception",
-    "terms": ["information desk"],
-    "category": "Scenes"
-  },
-  {
-    "name": "sleep",
-    "terms": ["bed", "night"],
-    "category": "Scenes"
-  },
-  {
-    "name": "presentation",
-    "terms": ["conference", "lecture", "webinar"],
-    "category": "Scenes"
-  },
-  {
-    "name": "canvas",
-    "terms": ["slate", "screen"],
-    "category": "Scenes"
-  },
-  {
-    "name": "tv",
-    "terms": ["television", "screen"],
-    "category": "Scenes"
-  },
-  {
-    "name": "break",
-    "terms": ["coffee", "pause", "relaxation"],
-    "category": "Scenes"
-  },
-  {
-    "name": "cleaning",
-    "category": "Scenes"
-  },
-  {
-    "name": "party",
-    "terms": ["celebration", "cocktail", "drinks"],
-    "category": "Scenes"
-  },
+  { "name": "reception", "terms": ["information desk"], "category": "Scenes" },
+  { "name": "sleep", "terms": ["bed", "night"], "category": "Scenes" },
+  { "name": "presentation", "terms": ["conference", "lecture", "webinar"], "category": "Scenes" },
+  { "name": "canvas", "terms": ["slate", "screen"], "category": "Scenes" },
+  { "name": "tv", "terms": ["television", "screen"], "category": "Scenes" },
+  { "name": "break", "terms": ["coffee", "pause", "relaxation"], "category": "Scenes" },
+  { "name": "cleaning", "category": "Scenes" },
+  { "name": "party", "terms": ["celebration", "cocktail", "drinks"], "category": "Scenes" },
   {
     "name": "dinner",
     "terms": ["cutlery", "knife", "fork", "meal", "eating", "food"],
     "category": "Scenes"
   },
-  {
-    "name": "couch",
-    "terms": ["sofa", "relaxation"],
-    "category": "Scenes"
-  },
-  {
-    "name": "fireplace",
-    "category": "Scenes"
-  },
+  { "name": "couch", "terms": ["sofa", "relaxation"], "category": "Scenes" },
+  { "name": "fireplace", "category": "Scenes" },
   {
     "name": "holiday",
     "terms": ["luggage", "suitcase", "vacation", "travel"],
     "category": "Scenes"
   },
-  {
-    "name": "do-not-disturb",
-    "terms": ["door hanger", "service"],
-    "category": "Scenes"
-  },
-  {
-    "name": "make-room",
-    "terms": ["door hanger", "service"],
-    "category": "Scenes"
-  },
-  {
-    "name": "service",
-    "terms": ["door hanger"],
-    "category": "Scenes"
-  },
-  {
-    "name": "couch",
-    "terms": ["sofa", "relaxation"],
-    "category": "Residential"
-  },
-  {
-    "name": "fireplace",
-    "category": "Residential"
-  },
-  {
-    "name": "kitchen",
-    "terms": ["pot", "pan", "cooking", "meal"],
-    "category": "Residential"
-  },
+  { "name": "do-not-disturb", "terms": ["door hanger", "service"], "category": "Scenes" },
+  { "name": "make-room", "terms": ["door hanger", "service"], "category": "Scenes" },
+  { "name": "service", "terms": ["door hanger"], "category": "Scenes" },
+  { "name": "couch", "terms": ["sofa", "relaxation"], "category": "Residential" },
+  { "name": "fireplace", "category": "Residential" },
+  { "name": "kitchen", "terms": ["pot", "pan", "cooking", "meal"], "category": "Residential" },
   {
     "name": "dinner",
     "terms": ["cutlery", "knife", "fork", "meal", "eating", "food"],
     "category": "Residential"
   },
-  {
-    "name": "library",
-    "terms": ["books", "literature", "information"],
-    "category": "Residential"
-  },
-  {
-    "name": "office",
-    "terms": ["chair", "work"],
-    "category": "Residential"
-  },
+  { "name": "library", "terms": ["books", "literature", "information"], "category": "Residential" },
+  { "name": "office", "terms": ["chair", "work"], "category": "Residential" },
   { "name": "childrenroom", "terms": ["nursery"], "category": "Residential" },
   { "name": "gaming", "terms": ["controller", "games"], "category": "Residential" },
   {
@@ -612,16 +201,8 @@
     "terms": ["equipment room", "utility room"],
     "category": "Residential"
   },
-  {
-    "name": "sleep",
-    "terms": ["bed", "night"],
-    "category": "Residential"
-  },
-  {
-    "name": "bath",
-    "terms": ["shower"],
-    "category": "Residential"
-  },
+  { "name": "sleep", "terms": ["bed", "night"], "category": "Residential" },
+  { "name": "bath", "terms": ["shower"], "category": "Residential" },
   {
     "name": "lobby",
     "terms": ["clothing hanger", "foyer", "entrance hall", "hallway", "wardrobe"],
@@ -629,138 +210,37 @@
   },
   { "name": "restroom", "terms": ["toilet"], "category": "Residential" },
   { "name": "toilet-paper", "terms": ["toilet"], "category": "Residential" },
-  {
-    "name": "winecellar",
-    "terms": ["bottles"],
-    "category": "Residential"
-  },
-  {
-    "name": "garden",
-    "terms": ["flower", "plants"],
-    "category": "Residential"
-  },
-  {
-    "name": "pool",
-    "terms": ["swimming", "bathing"],
-    "category": "Residential"
-  },
+  { "name": "winecellar", "terms": ["bottles"], "category": "Residential" },
+  { "name": "garden", "terms": ["flower", "plants"], "category": "Residential" },
+  { "name": "pool", "terms": ["swimming", "bathing"], "category": "Residential" },
   {
     "name": "gym",
     "terms": ["work out", "fitness", "sports", "exercise"],
     "category": "Residential"
   },
-  {
-    "name": "basement",
-    "terms": ["cellar"],
-    "category": "Residential"
-  },
-  {
-    "name": "oven-on",
-    "terms": ["baking"],
-    "category": "Residential"
-  },
-  {
-    "name": "oven-off",
-    "terms": ["baking"],
-    "category": "Residential"
-  },
-  {
-    "name": "dishwasher",
-    "category": "Residential"
-  },
-  {
-    "name": "washing-machine",
-    "terms": ["cleaning"],
-    "category": "Residential"
-  },
-  {
-    "name": "fridge",
-    "terms": ["freezer"],
-    "category": "Residential"
-  },
-  {
-    "name": "microwave-on",
-    "category": "Residential"
-  },
-  {
-    "name": "microwave-off",
-    "category": "Residential"
-  },
-  {
-    "name": "fume-on",
-    "terms": ["extractor hood", "range hood"],
-    "category": "Residential"
-  },
-  {
-    "name": "fume-off",
-    "terms": ["extractor hood", "range hood"],
-    "category": "Residential"
-  },
-  {
-    "name": "radiator",
-    "terms": ["heater", "convector"],
-    "category": "Residential"
-  },
-  {
-    "name": "garage-open",
-    "terms": ["car", "parking"],
-    "category": "Residential"
-  },
-  {
-    "name": "garage-closed",
-    "terms": ["car", "parking"],
-    "category": "Residential"
-  },
-  {
-    "name": "fountain-on",
-    "terms": ["water"],
-    "category": "Residential"
-  },
-  {
-    "name": "fountain-off",
-    "terms": ["water"],
-    "category": "Residential"
-  },
-  {
-    "name": "plant",
-    "terms": ["campus", "site"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-acknowledged",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-off",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-background",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-tick",
-    "terms": ["mark", "ckeck"],
-    "category": "Application"
-  },
-  {
-    "name": "scheduler",
-    "terms": ["clock", "time"],
-    "category": "Application"
-  },
-  {
-    "name": "favorites",
-    "terms": ["star", "highlighted"],
-    "category": "Application"
-  },
+  { "name": "basement", "terms": ["cellar"], "category": "Residential" },
+  { "name": "oven-on", "terms": ["baking"], "category": "Residential" },
+  { "name": "oven-off", "terms": ["baking"], "category": "Residential" },
+  { "name": "dishwasher", "category": "Residential" },
+  { "name": "washing-machine", "terms": ["cleaning"], "category": "Residential" },
+  { "name": "fridge", "terms": ["freezer"], "category": "Residential" },
+  { "name": "microwave-on", "category": "Residential" },
+  { "name": "microwave-off", "category": "Residential" },
+  { "name": "fume-on", "terms": ["extractor hood", "range hood"], "category": "Residential" },
+  { "name": "fume-off", "terms": ["extractor hood", "range hood"], "category": "Residential" },
+  { "name": "radiator", "terms": ["heater", "convector"], "category": "Residential" },
+  { "name": "garage-open", "terms": ["car", "parking"], "category": "Residential" },
+  { "name": "garage-closed", "terms": ["car", "parking"], "category": "Residential" },
+  { "name": "fountain-on", "terms": ["water"], "category": "Residential" },
+  { "name": "fountain-off", "terms": ["water"], "category": "Residential" },
+  { "name": "plant", "terms": ["campus", "site"], "category": "Application" },
+  { "name": "alarm", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-acknowledged", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-off", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-background", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-tick", "terms": ["mark", "ckeck"], "category": "Application" },
+  { "name": "scheduler", "terms": ["clock", "time"], "category": "Application" },
+  { "name": "favorites", "terms": ["star", "highlighted"], "category": "Application" },
   {
     "name": "trend",
     "terms": ["performance", "statistics", "graph", "analytics", "growth chart"],
@@ -776,35 +256,20 @@
     "terms": ["statistics", "documentation", "analytics"],
     "category": "Application"
   },
-  {
-    "name": "heat-map",
-    "category": "Application"
-  },
+  { "name": "heat-map", "category": "Application" },
   {
     "name": "log",
     "terms": ["documentation", "record", "archive", "history", "entry"],
     "category": "Application"
   },
-  {
-    "name": "diagnostic",
-    "terms": ["ekg", "cardiogram", "heartbeat"],
-    "category": "Application"
-  },
-  {
-    "name": "dashboard",
-    "terms": ["panel", "monitor", "circle chart"],
-    "category": "Application"
-  },
+  { "name": "diagnostic", "terms": ["ekg", "cardiogram", "heartbeat"], "category": "Application" },
+  { "name": "dashboard", "terms": ["panel", "monitor", "circle chart"], "category": "Application" },
   {
     "name": "security",
     "terms": ["shield", "safety", "protection", "privacy"],
     "category": "Application"
   },
-  {
-    "name": "maintenance",
-    "terms": ["wrench", "tool"],
-    "category": "Application"
-  },
+  { "name": "maintenance", "terms": ["wrench", "tool"], "category": "Application" },
   {
     "name": "settings",
     "terms": ["options", "adjustments", "preferences", "gear"],
@@ -815,41 +280,13 @@
     "terms": ["flow chart", "process", "diagram", "connection", "mapping", "workflow"],
     "category": "Application"
   },
-  {
-    "name": "plant-filled",
-    "terms": ["campus", "site"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-filled",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-off-filled",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-acknowledged-filled",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "alarm-background-filled",
-    "terms": ["bell", "event"],
-    "category": "Application"
-  },
-  {
-    "name": "scheduler-filled",
-    "terms": ["clock", "time"],
-    "category": "Application"
-  },
-  {
-    "name": "favorites-filled",
-    "terms": ["star", "highlighted"],
-    "category": "Application"
-  },
+  { "name": "plant-filled", "terms": ["campus", "site"], "category": "Application" },
+  { "name": "alarm-filled", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-off-filled", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-acknowledged-filled", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "alarm-background-filled", "terms": ["bell", "event"], "category": "Application" },
+  { "name": "scheduler-filled", "terms": ["clock", "time"], "category": "Application" },
+  { "name": "favorites-filled", "terms": ["star", "highlighted"], "category": "Application" },
   {
     "name": "trend-filled",
     "terms": ["performance", "statistics", "graph", "analytics", "growth chart"],
@@ -870,21 +307,13 @@
     "terms": ["ekg", "cardiogram", "heartbeat"],
     "category": "Application"
   },
-  {
-    "name": "dashboard-filled",
-    "terms": ["panel", "monitor"],
-    "category": "Application"
-  },
+  { "name": "dashboard-filled", "terms": ["panel", "monitor"], "category": "Application" },
   {
     "name": "security-filled",
     "terms": ["shield", "safety", "protection", "privacy"],
     "category": "Application"
   },
-  {
-    "name": "maintenance-filled",
-    "terms": ["wrench", "tool"],
-    "category": "Application"
-  },
+  { "name": "maintenance-filled", "terms": ["wrench", "tool"], "category": "Application" },
   {
     "name": "settings-filled",
     "terms": ["options", "adjustments", "preferences", "gear"],
@@ -895,314 +324,84 @@
     "terms": ["flow chart", "process", "diagram", "connection", "mapping", "workflow"],
     "category": "Application"
   },
-  {
-    "name": "manual",
-    "terms": ["hand"],
-    "category": "Object states"
-  },
-  {
-    "name": "manual-alt-1",
-    "terms": ["hand"],
-    "category": "Object states"
-  },
-  {
-    "name": "manual-alt-2",
-    "terms": ["hand"],
-    "category": "Object states"
-  },
-  {
-    "name": "manual-alt-3",
-    "terms": ["hand"],
-    "category": "Object states"
-  },
-  {
-    "name": "out-of-service",
-    "terms": ["unavailable", "prohibited"],
-    "category": "Object states"
-  },
-  {
-    "name": "delay",
-    "category": "Object states"
-  },
-  {
-    "name": "transient",
-    "category": "Object states"
-  },
-  {
-    "name": "checked",
-    "terms": ["tick", "selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "not-checked",
-    "terms": ["not selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "radio-checked",
-    "terms": ["recording"],
-    "category": "Object states"
-  },
-  {
-    "name": "checkbox-checked",
-    "terms": ["tick", "selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "checkbox-unchecked",
-    "terms": ["not selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "checkbox-partially",
-    "category": "Object states"
-  },
-  {
-    "name": "manual-filled",
-    "terms": ["hand"],
-    "category": "Object states"
-  },
-  {
-    "name": "checked-filled",
-    "terms": ["tick", "selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "checkbox-checked-filled",
-    "terms": ["tick", "selected"],
-    "category": "Object states"
-  },
-  {
-    "name": "network",
-    "category": "Network"
-  },
-  {
-    "name": "network-backbone",
-    "category": "Network"
-  },
-  {
-    "name": "connection",
-    "category": "Network"
-  },
-  {
-    "name": "connection-alt",
-    "category": "Network"
-  },
-  {
-    "name": "router",
-    "category": "Network"
-  },
-  {
-    "name": "router-off",
-    "category": "Network"
-  },
-  {
-    "name": "repeater",
-    "category": "Network"
-  },
-  {
-    "name": "network-port",
-    "category": "Network"
-  },
-  {
-    "name": "home",
-    "terms": ["house"],
-    "category": "General"
-  },
-  {
-    "name": "thumbnails",
-    "terms": ["previews", "overview"],
-    "category": "General"
-  },
-  {
-    "name": "item",
-    "terms": ["object, element"],
-    "category": "General"
-  },
-  {
-    "name": "menu",
-    "terms": ["hamburger", "navigation"],
-    "category": "General"
-  },
-  {
-    "name": "list",
-    "terms": ["bullet points", "enumeration", "sequence"],
-    "category": "General"
-  },
-  {
-    "name": "jump-to-list-item",
-    "category": "General"
-  },
-  {
-    "name": "view-toggle",
-    "category": "General"
-  },
-  {
-    "name": "queue",
-    "terms": ["waiting list"],
-    "category": "General"
-  },
+  { "name": "manual", "terms": ["hand"], "category": "Object states" },
+  { "name": "manual-alt-1", "terms": ["hand"], "category": "Object states" },
+  { "name": "manual-alt-2", "terms": ["hand"], "category": "Object states" },
+  { "name": "manual-alt-3", "terms": ["hand"], "category": "Object states" },
+  { "name": "out-of-service", "terms": ["unavailable", "prohibited"], "category": "Object states" },
+  { "name": "delay", "category": "Object states" },
+  { "name": "transient", "category": "Object states" },
+  { "name": "checked", "terms": ["tick", "selected"], "category": "Object states" },
+  { "name": "not-checked", "terms": ["not selected"], "category": "Object states" },
+  { "name": "radio-checked", "terms": ["recording"], "category": "Object states" },
+  { "name": "checkbox-checked", "terms": ["tick", "selected"], "category": "Object states" },
+  { "name": "checkbox-unchecked", "terms": ["not selected"], "category": "Object states" },
+  { "name": "checkbox-partially", "category": "Object states" },
+  { "name": "manual-filled", "terms": ["hand"], "category": "Object states" },
+  { "name": "checked-filled", "terms": ["tick", "selected"], "category": "Object states" },
+  { "name": "checkbox-checked-filled", "terms": ["tick", "selected"], "category": "Object states" },
+  { "name": "network", "category": "Network" },
+  { "name": "network-backbone", "category": "Network" },
+  { "name": "connection", "category": "Network" },
+  { "name": "connection-alt", "category": "Network" },
+  { "name": "router", "category": "Network" },
+  { "name": "router-off", "category": "Network" },
+  { "name": "repeater", "category": "Network" },
+  { "name": "network-port", "category": "Network" },
+  { "name": "home", "terms": ["house"], "category": "General" },
+  { "name": "thumbnails", "terms": ["previews", "overview"], "category": "General" },
+  { "name": "item", "terms": ["object, element"], "category": "General" },
+  { "name": "menu", "terms": ["hamburger", "navigation"], "category": "General" },
+  { "name": "list", "terms": ["bullet points", "enumeration", "sequence"], "category": "General" },
+  { "name": "jump-to-list-item", "category": "General" },
+  { "name": "view-toggle", "category": "General" },
+  { "name": "queue", "terms": ["waiting list"], "category": "General" },
   {
     "name": "parameter",
     "terms": ["adjustments", "preferences", "customization"],
     "category": "General"
   },
-  {
-    "name": "options",
-    "terms": ["more"],
-    "category": "General"
-  },
-  {
-    "name": "options-vertical",
-    "terms": ["more"],
-    "category": "General"
-  },
-  {
-    "name": "link",
-    "terms": ["attachment", "url", "path"],
-    "category": "General"
-  },
-  {
-    "name": "link-broken",
-    "terms": ["attachment", "url", "path"],
-    "category": "General"
-  },
-  {
-    "name": "clock",
-    "terms": ["time"],
-    "category": "General"
-  },
-  {
-    "name": "timer",
-    "terms": ["clock", "time"],
-    "category": "General"
-  },
-  {
-    "name": "calendar",
-    "terms": ["agenda"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-thermostat",
-    "terms": ["temperature"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-dhw",
-    "terms": ["domestic hot water"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-fan",
-    "terms": ["ventilator"],
-    "category": "General"
-  },
-  {
-    "name": "date",
-    "category": "General"
-  },
-  {
-    "name": "date-range",
-    "category": "General"
-  },
-  {
-    "name": "recurring",
-    "category": "General"
-  },
-  {
-    "name": "weekday",
-    "category": "General"
-  },
+  { "name": "options", "terms": ["more"], "category": "General" },
+  { "name": "options-vertical", "terms": ["more"], "category": "General" },
+  { "name": "link", "terms": ["attachment", "url", "path"], "category": "General" },
+  { "name": "link-broken", "terms": ["attachment", "url", "path"], "category": "General" },
+  { "name": "clock", "terms": ["time"], "category": "General" },
+  { "name": "timer", "terms": ["clock", "time"], "category": "General" },
+  { "name": "calendar", "terms": ["agenda"], "category": "General" },
+  { "name": "scheduler-thermostat", "terms": ["temperature"], "category": "General" },
+  { "name": "scheduler-dhw", "terms": ["domestic hot water"], "category": "General" },
+  { "name": "scheduler-fan", "terms": ["ventilator"], "category": "General" },
+  { "name": "date", "category": "General" },
+  { "name": "date-range", "category": "General" },
+  { "name": "recurring", "category": "General" },
+  { "name": "weekday", "category": "General" },
   { "name": "booked", "category": "General" },
   { "name": "date-unavailable", "category": "General" },
   { "name": "booking-overview", "category": "General" },
-  {
-    "name": "address-book",
-    "terms": ["contacts"],
-    "category": "General"
-  },
-  {
-    "name": "language",
-    "category": "General"
-  },
-  {
-    "name": "chat",
-    "category": "General"
-  },
-  {
-    "name": "notification",
-    "category": "General"
-  },
-  {
-    "name": "notification-off",
-    "category": "General"
-  },
-  {
-    "name": "notification-unread",
-    "category": "General"
-  },
-  {
-    "name": "message",
-    "terms": ["text", "chat"],
-    "category": "General"
-  },
-  {
-    "name": "box",
-    "category": "General"
-  },
-  {
-    "name": "scalability",
-    "category": "General"
-  },
-  {
-    "name": "quality",
-    "category": "General"
-  },
-  {
-    "name": "rocket",
-    "category": "General"
-  },
-  {
-    "name": "global",
-    "terms": ["worldwide", "international"],
-    "category": "General"
-  },
-  {
-    "name": "legal",
-    "category": "General"
-  },
-  {
-    "name": "filter",
-    "category": "General"
-  },
-  {
-    "name": "key",
-    "category": "General"
-  },
-  {
-    "name": "key-alt",
-    "category": "General"
-  },
-  {
-    "name": "image",
-    "terms": ["photograph", "picture"],
-    "category": "General"
-  },
+  { "name": "address-book", "terms": ["contacts"], "category": "General" },
+  { "name": "language", "category": "General" },
+  { "name": "chat", "category": "General" },
+  { "name": "notification", "category": "General" },
+  { "name": "notification-off", "category": "General" },
+  { "name": "notification-unread", "category": "General" },
+  { "name": "message", "terms": ["text", "chat"], "category": "General" },
+  { "name": "box", "category": "General" },
+  { "name": "scalability", "category": "General" },
+  { "name": "quality", "category": "General" },
+  { "name": "rocket", "category": "General" },
+  { "name": "global", "terms": ["worldwide", "international"], "category": "General" },
+  { "name": "legal", "category": "General" },
+  { "name": "filter", "category": "General" },
+  { "name": "key", "category": "General" },
+  { "name": "key-alt", "category": "General" },
+  { "name": "image", "terms": ["photograph", "picture"], "category": "General" },
   {
     "name": "palette",
     "terms": ["colors", "color scheme", "color theme", "painting"],
     "category": "General"
   },
-  {
-    "name": "brush",
-    "terms": ["formatting", "painting"],
-    "category": "General"
-  },
-  {
-    "name": "phone",
-    "terms": ["call", "mobile"],
-    "category": "General"
-  },
+  { "name": "brush", "terms": ["formatting", "painting"], "category": "General" },
+  { "name": "phone", "terms": ["call", "mobile"], "category": "General" },
   {
     "name": "money",
     "terms": ["cash", "finance", "capital", "price", "cost", "currency", "funds", "resources"],
@@ -1243,174 +442,47 @@
     ],
     "category": "General"
   },
-  {
-    "name": "horn",
-    "terms": ["acoustic signal", "siren"],
-    "category": "General"
-  },
-  {
-    "name": "horn-off",
-    "terms": ["acoustic signal", "siren"],
-    "category": "General"
-  },
-  {
-    "name": "cloud",
-    "terms": ["remote storage"],
-    "category": "General"
-  },
-  {
-    "name": "cloud-connection-lost",
-    "terms": ["remote storage"],
-    "category": "General"
-  },
-  {
-    "name": "binary",
-    "terms": ["switch", "toggle", "on/off"],
-    "category": "General"
-  },
-  {
-    "name": "multistate",
-    "terms": ["selector"],
-    "category": "General"
-  },
-  {
-    "name": "analog",
-    "terms": ["signal"],
-    "category": "General"
-  },
-  {
-    "name": "analog-manual",
-    "terms": ["signal"],
-    "category": "General"
-  },
-  {
-    "name": "analog-external",
-    "terms": ["signal"],
-    "category": "General"
-  },
-  {
-    "name": "control",
-    "category": "General"
-  },
-  {
-    "name": "control-manual",
-    "category": "General"
-  },
-  {
-    "name": "control-external",
-    "category": "General"
-  },
-  {
-    "name": "status",
-    "category": "General"
-  },
-  {
-    "name": "status-manual",
-    "category": "General"
-  },
-  {
-    "name": "status-external",
-    "category": "General"
-  },
-  {
-    "name": "print",
-    "category": "General"
-  },
-  {
-    "name": "camera",
-    "terms": ["photograph", "picture"],
-    "category": "General"
-  },
-  {
-    "name": "camera-flip",
-    "terms": ["photograph", "picture"],
-    "category": "General"
-  },
-  {
-    "name": "shopping-cart",
-    "terms": ["buy"],
-    "category": "General"
-  },
-  {
-    "name": "train",
-    "category": "General"
-  },
-  {
-    "name": "factory-reset",
-    "category": "General"
-  },
-  {
-    "name": "wiringtest",
-    "category": "General"
-  },
-  {
-    "name": "connection-established",
-    "category": "General"
-  },
-  {
-    "name": "connection-lost",
-    "category": "General"
-  },
-  {
-    "name": "connected",
-    "terms": ["linked", "coupled"],
-    "category": "General"
-  },
-  {
-    "name": "disconnected",
-    "terms": ["linked", "coupled"],
-    "category": "General"
-  },
-  {
-    "name": "programmode",
-    "category": "General"
-  },
-  {
-    "name": "code",
-    "terms": ["coding", "programming"],
-    "category": "General"
-  },
-  {
-    "name": "code-working",
-    "terms": ["coding", "programming"],
-    "category": "General"
-  },
+  { "name": "horn", "terms": ["acoustic signal", "siren"], "category": "General" },
+  { "name": "horn-off", "terms": ["acoustic signal", "siren"], "category": "General" },
+  { "name": "cloud", "terms": ["remote storage"], "category": "General" },
+  { "name": "cloud-connection-lost", "terms": ["remote storage"], "category": "General" },
+  { "name": "binary", "terms": ["switch", "toggle", "on/off"], "category": "General" },
+  { "name": "multistate", "terms": ["selector"], "category": "General" },
+  { "name": "analog", "terms": ["signal"], "category": "General" },
+  { "name": "analog-manual", "terms": ["signal"], "category": "General" },
+  { "name": "analog-external", "terms": ["signal"], "category": "General" },
+  { "name": "control", "category": "General" },
+  { "name": "control-manual", "category": "General" },
+  { "name": "control-external", "category": "General" },
+  { "name": "status", "category": "General" },
+  { "name": "status-manual", "category": "General" },
+  { "name": "status-external", "category": "General" },
+  { "name": "print", "category": "General" },
+  { "name": "camera", "terms": ["photograph", "picture"], "category": "General" },
+  { "name": "camera-flip", "terms": ["photograph", "picture"], "category": "General" },
+  { "name": "shopping-cart", "terms": ["buy"], "category": "General" },
+  { "name": "train", "category": "General" },
+  { "name": "factory-reset", "category": "General" },
+  { "name": "wiringtest", "category": "General" },
+  { "name": "connection-established", "category": "General" },
+  { "name": "connection-lost", "category": "General" },
+  { "name": "connected", "terms": ["linked", "coupled"], "category": "General" },
+  { "name": "disconnected", "terms": ["linked", "coupled"], "category": "General" },
+  { "name": "programmode", "category": "General" },
+  { "name": "code", "terms": ["coding", "programming"], "category": "General" },
+  { "name": "code-working", "terms": ["coding", "programming"], "category": "General" },
   {
     "name": "terminal",
     "terms": ["console", "shell", "command prompt", "command line"],
     "category": "General"
   },
-  {
-    "name": "merge",
-    "terms": ["join"],
-    "category": "General"
-  },
-  {
-    "name": "baseline",
-    "category": "General"
-  },
-  {
-    "name": "baseline-mismatch",
-    "category": "General"
-  },
-  {
-    "name": "backspace",
-    "terms": ["delete"],
-    "category": "General"
-  },
-  {
-    "name": "spacebar",
-    "terms": ["space key", "blank key"],
-    "category": "General"
-  },
-  {
-    "name": "keyboard",
-    "category": "General"
-  },
-  {
-    "name": "inputfield",
-    "category": "General"
-  },
+  { "name": "merge", "terms": ["join"], "category": "General" },
+  { "name": "baseline", "category": "General" },
+  { "name": "baseline-mismatch", "category": "General" },
+  { "name": "backspace", "terms": ["delete"], "category": "General" },
+  { "name": "spacebar", "terms": ["space key", "blank key"], "category": "General" },
+  { "name": "keyboard", "category": "General" },
+  { "name": "inputfield", "category": "General" },
   {
     "name": "thumbs-up",
     "terms": ["like", "upvote", "positive feedback", "approval"],
@@ -1421,11 +493,7 @@
     "terms": ["dislike", "downvote", "negative feedback", "rejection"],
     "category": "General"
   },
-  {
-    "name": "send",
-    "terms": ["submit"],
-    "category": "General"
-  },
+  { "name": "send", "terms": ["submit"], "category": "General" },
   {
     "name": "alchemy-flask",
     "terms": ["chemistry", "laboratory", "experiment", "science", "research"],
@@ -1442,184 +510,54 @@
     "terms": ["corporate contact", "corporate address"],
     "category": "General"
   },
-  {
-    "name": "theme-auto",
-    "category": "General"
-  },
-  {
-    "name": "comparison",
-    "category": "General"
-  },
+  { "name": "theme-auto", "category": "General" },
+  { "name": "comparison", "category": "General" },
   { "name": "hexagon-vertical-bars", "category": "General" },
   { "name": "hexagon-vertical-bars-database", "category": "General" },
-  {
-    "name": "home-filled",
-    "terms": ["house"],
-    "category": "General"
-  },
+  { "name": "home-filled", "terms": ["house"], "category": "General" },
   {
     "name": "parameter-filled",
     "terms": ["adjustments", "preferences", "customization"],
     "category": "General"
   },
-  {
-    "name": "clock-filled",
-    "terms": ["time"],
-    "category": "General"
-  },
-  {
-    "name": "calendar-filled",
-    "terms": ["agenda"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-thermostat-filled",
-    "terms": ["temperature"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-dhw-filled",
-    "terms": ["domestic hot water"],
-    "category": "General"
-  },
-  {
-    "name": "scheduler-fan-filled",
-    "terms": ["ventilator"],
-    "category": "General"
-  },
-  {
-    "name": "address-book-filled",
-    "terms": ["contacts"],
-    "category": "General"
-  },
-  {
-    "name": "language-filled",
-    "category": "General"
-  },
-  {
-    "name": "phone-filled",
-    "terms": ["call", "mobile"],
-    "category": "General"
-  },
-  {
-    "name": "horn-filled",
-    "terms": ["acoustic signal", "siren"],
-    "category": "General"
-  },
-  {
-    "name": "horn-off-filled",
-    "terms": ["acoustic signal", "siren"],
-    "category": "General"
-  },
-  {
-    "name": "notification-filled",
-    "category": "General"
-  },
-  {
-    "name": "message-filled",
-    "terms": ["text", "chat"],
-    "category": "General"
-  },
-  {
-    "name": "cloud-filled",
-    "terms": ["remote storage"],
-    "category": "General"
-  },
-  {
-    "name": "cloud-connection-lost-filled",
-    "terms": ["remote storage"],
-    "category": "General"
-  },
-  {
-    "name": "binary-filled",
-    "terms": ["switch", "toggle", "on/off"],
-    "category": "General"
-  },
-  {
-    "name": "chat-filled",
-    "category": "General"
-  },
-  {
-    "name": "rocket-filled",
-    "category": "General"
-  },
-  {
-    "name": "global-filled",
-    "terms": ["worldwide", "international"],
-    "category": "General"
-  },
-  {
-    "name": "filter-filled",
-    "category": "General"
-  },
-  {
-    "name": "key-filled",
-    "category": "General"
-  },
-  {
-    "name": "key-alt-filled",
-    "category": "General"
-  },
-  {
-    "name": "image-filled",
-    "terms": ["photograph", "picture"],
-    "category": "General"
-  },
+  { "name": "clock-filled", "terms": ["time"], "category": "General" },
+  { "name": "calendar-filled", "terms": ["agenda"], "category": "General" },
+  { "name": "scheduler-thermostat-filled", "terms": ["temperature"], "category": "General" },
+  { "name": "scheduler-dhw-filled", "terms": ["domestic hot water"], "category": "General" },
+  { "name": "scheduler-fan-filled", "terms": ["ventilator"], "category": "General" },
+  { "name": "address-book-filled", "terms": ["contacts"], "category": "General" },
+  { "name": "language-filled", "category": "General" },
+  { "name": "phone-filled", "terms": ["call", "mobile"], "category": "General" },
+  { "name": "horn-filled", "terms": ["acoustic signal", "siren"], "category": "General" },
+  { "name": "horn-off-filled", "terms": ["acoustic signal", "siren"], "category": "General" },
+  { "name": "notification-filled", "category": "General" },
+  { "name": "message-filled", "terms": ["text", "chat"], "category": "General" },
+  { "name": "cloud-filled", "terms": ["remote storage"], "category": "General" },
+  { "name": "cloud-connection-lost-filled", "terms": ["remote storage"], "category": "General" },
+  { "name": "binary-filled", "terms": ["switch", "toggle", "on/off"], "category": "General" },
+  { "name": "chat-filled", "category": "General" },
+  { "name": "rocket-filled", "category": "General" },
+  { "name": "global-filled", "terms": ["worldwide", "international"], "category": "General" },
+  { "name": "filter-filled", "category": "General" },
+  { "name": "key-filled", "category": "General" },
+  { "name": "key-alt-filled", "category": "General" },
+  { "name": "image-filled", "terms": ["photograph", "picture"], "category": "General" },
   {
     "name": "palette-filled",
     "terms": ["colors", "color scheme", "color theme", "painting"],
     "category": "General"
   },
-  {
-    "name": "brush-filled",
-    "terms": ["formatting", "painting"],
-    "category": "General"
-  },
-  {
-    "name": "print-filled",
-    "category": "General"
-  },
-  {
-    "name": "camera-filled",
-    "terms": ["photograph", "picture"],
-    "category": "General"
-  },
-  {
-    "name": "shopping-cart-filled",
-    "terms": ["buy"],
-    "category": "General"
-  },
-  {
-    "name": "wiringtest-filled",
-    "category": "General"
-  },
-  {
-    "name": "connection-established-filled",
-    "category": "General"
-  },
-  {
-    "name": "connection-lost-filled",
-    "category": "General"
-  },
-  {
-    "name": "connected-filled",
-    "terms": ["linked", "coupled"],
-    "category": "General"
-  },
-  {
-    "name": "disconnected-filled",
-    "terms": ["linked", "coupled"],
-    "category": "General"
-  },
-  {
-    "name": "backspace-filled",
-    "terms": ["delete"],
-    "category": "General"
-  },
-  {
-    "name": "keyboard-filled",
-    "category": "General"
-  },
+  { "name": "brush-filled", "terms": ["formatting", "painting"], "category": "General" },
+  { "name": "print-filled", "category": "General" },
+  { "name": "camera-filled", "terms": ["photograph", "picture"], "category": "General" },
+  { "name": "shopping-cart-filled", "terms": ["buy"], "category": "General" },
+  { "name": "wiringtest-filled", "category": "General" },
+  { "name": "connection-established-filled", "category": "General" },
+  { "name": "connection-lost-filled", "category": "General" },
+  { "name": "connected-filled", "terms": ["linked", "coupled"], "category": "General" },
+  { "name": "disconnected-filled", "terms": ["linked", "coupled"], "category": "General" },
+  { "name": "backspace-filled", "terms": ["delete"], "category": "General" },
+  { "name": "keyboard-filled", "category": "General" },
   {
     "name": "thumbs-up-filled",
     "terms": ["like", "upvote", "positive feedback", "approval"],
@@ -1630,11 +568,7 @@
     "terms": ["dislike", "downvote", "negative feedback", "rejection"],
     "category": "General"
   },
-  {
-    "name": "send-filled",
-    "terms": ["submit"],
-    "category": "General"
-  },
+  { "name": "send-filled", "terms": ["submit"], "category": "General" },
   {
     "name": "collaboration-filled",
     "terms": ["cooperation", "partnership", " teamwork"],
@@ -1647,32 +581,15 @@
   },
   { "name": "hexagon-vertical-bars-filled", "category": "General" },
   { "name": "hexagon-vertical-bars-database-filled", "category": "General" },
-  {
-    "name": "clock",
-    "terms": ["time"],
-    "tags": ["auto"],
-    "category": "Operating mode"
-  },
-  {
-    "name": "sun",
-    "terms": ["light", "day"],
-    "tags": ["comfort"],
-    "category": "Operating mode"
-  },
-  {
-    "name": "precomfort",
-    "category": "Operating mode"
-  },
+  { "name": "clock", "terms": ["time"], "tags": ["auto"], "category": "Operating mode" },
+  { "name": "sun", "terms": ["light", "day"], "tags": ["comfort"], "category": "Operating mode" },
+  { "name": "precomfort", "category": "Operating mode" },
   {
     "name": "economy",
     "terms": ["moon", "night", "energy-efficient", "energy saving"],
     "category": "Operating mode"
   },
-  {
-    "name": "protection",
-    "terms": ["security", "safety"],
-    "category": "Operating mode"
-  },
+  { "name": "protection", "terms": ["security", "safety"], "category": "Operating mode" },
   {
     "name": "standby",
     "terms": ["energy-efficient", "energy saving"],
@@ -1683,211 +600,61 @@
     "terms": ["sustainability", "environmentally friendly", "energy-efficient", "energy saving"],
     "category": "Operating mode"
   },
-  {
-    "name": "cooling-state",
-    "terms": ["snowflake"],
-    "category": "States"
-  },
-  {
-    "name": "heat",
-    "terms": ["hot"],
-    "category": "States"
-  },
-  {
-    "name": "heating-state",
-    "terms": ["hot", "radiator"],
-    "category": "States"
-  },
-  {
-    "name": "heating-reduced",
-    "terms": ["hot", "radiator"],
-    "category": "States"
-  },
-  {
-    "name": "humidification",
-    "terms": ["moisture", "water"],
-    "category": "States"
-  },
-  {
-    "name": "dehumidification",
-    "terms": ["moisture", "water"],
-    "category": "States"
-  },
-  {
-    "name": "defrost",
-    "terms": ["cold", "freeze"],
-    "category": "States"
-  },
-  {
-    "name": "lock",
-    "category": "States"
-  },
-  {
-    "name": "partlock",
-    "category": "States"
-  },
-  {
-    "name": "unlock",
-    "category": "States"
-  },
-  {
-    "name": "window-open",
-    "category": "States"
-  },
-  {
-    "name": "window-closed",
-    "category": "States"
-  },
-  {
-    "name": "door",
-    "category": "States"
-  },
-  {
-    "name": "door-locked",
-    "category": "States"
-  },
-  {
-    "name": "door-closed",
-    "category": "States"
-  },
-  {
-    "name": "domelight-open",
-    "category": "States"
-  },
-  {
-    "name": "domelight-closed",
-    "category": "States"
-  },
-  {
-    "name": "rooflight-open",
-    "category": "States"
-  },
-  {
-    "name": "rooflight-closed",
-    "category": "States"
-  },
-  {
-    "name": "lock-filled",
-    "category": "States"
-  },
-  {
-    "name": "door-filled",
-    "category": "States"
-  },
-  {
-    "name": "on",
-    "category": "Multistate"
-  },
-  {
-    "name": "off",
-    "category": "Multistate"
-  },
-  {
-    "name": "enable",
-    "category": "Multistate"
-  },
-  {
-    "name": "disable",
-    "category": "Multistate"
-  },
+  { "name": "cooling-state", "terms": ["snowflake"], "category": "States" },
+  { "name": "heat", "terms": ["hot"], "category": "States" },
+  { "name": "heating-state", "terms": ["hot", "radiator"], "category": "States" },
+  { "name": "heating-reduced", "terms": ["hot", "radiator"], "category": "States" },
+  { "name": "humidification", "terms": ["moisture", "water"], "category": "States" },
+  { "name": "dehumidification", "terms": ["moisture", "water"], "category": "States" },
+  { "name": "defrost", "terms": ["cold", "freeze"], "category": "States" },
+  { "name": "lock", "category": "States" },
+  { "name": "partlock", "category": "States" },
+  { "name": "unlock", "category": "States" },
+  { "name": "window-open", "category": "States" },
+  { "name": "window-closed", "category": "States" },
+  { "name": "door", "category": "States" },
+  { "name": "door-locked", "category": "States" },
+  { "name": "door-closed", "category": "States" },
+  { "name": "domelight-open", "category": "States" },
+  { "name": "domelight-closed", "category": "States" },
+  { "name": "rooflight-open", "category": "States" },
+  { "name": "rooflight-closed", "category": "States" },
+  { "name": "lock-filled", "category": "States" },
+  { "name": "door-filled", "category": "States" },
+  { "name": "on", "category": "Multistate" },
+  { "name": "off", "category": "Multistate" },
+  { "name": "enable", "category": "Multistate" },
+  { "name": "disable", "category": "Multistate" },
   { "name": "circle-add", "category": "Multistate" },
   { "name": "circle-remove", "category": "Multistate" },
-  {
-    "name": "occupied",
-    "terms": ["taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "unoccupied",
-    "terms": ["not taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "unoccupied-alt",
-    "terms": ["not taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "unoccupied-alt-2",
-    "terms": ["not taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "beamer",
-    "terms": ["projector"],
-    "category": "Multistate"
-  },
+  { "name": "occupied", "terms": ["taken"], "category": "Multistate" },
+  { "name": "unoccupied", "terms": ["not taken"], "category": "Multistate" },
+  { "name": "unoccupied-alt", "terms": ["not taken"], "category": "Multistate" },
+  { "name": "unoccupied-alt-2", "terms": ["not taken"], "category": "Multistate" },
+  { "name": "beamer", "terms": ["projector"], "category": "Multistate" },
   {
     "name": "alarm-suppression-on",
     "terms": ["bell", "event", "silent", "mute"],
     "category": "Multistate"
   },
-  {
-    "name": "alarm-suppression-off",
-    "terms": ["bell", "event"],
-    "category": "Multistate"
-  },
-  {
-    "name": "on-filled",
-    "category": "Multistate"
-  },
-  {
-    "name": "off-filled",
-    "category": "Multistate"
-  },
-  {
-    "name": "enable-filled",
-    "category": "Multistate"
-  },
-  {
-    "name": "disable-filled",
-    "category": "Multistate"
-  },
-  {
-    "name": "occupied-filled",
-    "terms": ["taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "unoccupied-filled",
-    "terms": ["not taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "unoccupied-alt-2-filled",
-    "terms": ["not taken"],
-    "category": "Multistate"
-  },
-  {
-    "name": "beamer-filled",
-    "terms": ["projector"],
-    "category": "Multistate"
-  },
+  { "name": "alarm-suppression-off", "terms": ["bell", "event"], "category": "Multistate" },
+  { "name": "on-filled", "category": "Multistate" },
+  { "name": "off-filled", "category": "Multistate" },
+  { "name": "enable-filled", "category": "Multistate" },
+  { "name": "disable-filled", "category": "Multistate" },
+  { "name": "occupied-filled", "terms": ["taken"], "category": "Multistate" },
+  { "name": "unoccupied-filled", "terms": ["not taken"], "category": "Multistate" },
+  { "name": "unoccupied-alt-2-filled", "terms": ["not taken"], "category": "Multistate" },
+  { "name": "beamer-filled", "terms": ["projector"], "category": "Multistate" },
   {
     "name": "alarm-suppression-on-filled",
     "terms": ["bell", "event", "silent", "mute"],
     "category": "Multistate"
   },
-  {
-    "name": "alarm-suppression-off-filled",
-    "terms": ["bell", "event"],
-    "category": "Multistate"
-  },
-  {
-    "name": "summer",
-    "terms": ["sunshade", "parasol", "season"],
-    "category": "Climate"
-  },
-  {
-    "name": "winter",
-    "terms": ["snowman", "season"],
-    "category": "Climate"
-  },
-  {
-    "name": "sun",
-    "terms": ["light", "day"],
-    "category": "Climate"
-  },
+  { "name": "alarm-suppression-off-filled", "terms": ["bell", "event"], "category": "Multistate" },
+  { "name": "summer", "terms": ["sunshade", "parasol", "season"], "category": "Climate" },
+  { "name": "winter", "terms": ["snowman", "season"], "category": "Climate" },
+  { "name": "sun", "terms": ["light", "day"], "category": "Climate" },
   {
     "name": "cloudy",
     "terms": ["misty", "forecast", "weather", "meteorology"],
@@ -1913,131 +680,36 @@
     "terms": ["breeze", "blow", "forecast", "weather", "meteorology"],
     "category": "Climate"
   },
-  {
-    "name": "media",
-    "category": "Media"
-  },
-  {
-    "name": "multimedia",
-    "category": "Media"
-  },
+  { "name": "media", "category": "Media" },
+  { "name": "multimedia", "category": "Media" },
   {
     "name": "av-system",
     "terms": ["audio visual", "speaker", "sound", "acoustic", "screen"],
     "category": "Media"
   },
-  {
-    "name": "audio",
-    "terms": ["sound", "acoustic", "music", "musical note"],
-    "category": "Media"
-  },
-  {
-    "name": "audio-wave",
-    "terms": ["sound", "acoustic", "music", "audio"],
-    "category": "Media"
-  },
-  {
-    "name": "video",
-    "terms": ["movie", "film", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "video-off",
-    "terms": ["movie", "film", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "voice",
-    "terms": ["microphone", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "voice-off",
-    "terms": ["microphone", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-on",
-    "terms": ["audio", "acoustic"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-off",
-    "terms": ["audio", "acoustic", "silent"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-mute",
-    "terms": ["audio", "acoustic", "silent"],
-    "category": "Media"
-  },
-  {
-    "name": "play",
-    "terms": ["start", "resume", "continue"],
-    "category": "Media"
-  },
-  {
-    "name": "pause",
-    "terms": ["stop", "break", "halt"],
-    "category": "Media"
-  },
-  {
-    "name": "record",
-    "terms": ["register", "enroll"],
-    "category": "Media"
-  },
-  {
-    "name": "stop",
-    "terms": ["halt", "end"],
-    "category": "Media"
-  },
-  {
-    "name": "recording",
-    "category": "Media"
-  },
-  {
-    "name": "fast-rewind",
-    "terms": ["last", "back", "reverse"],
-    "category": "Media"
-  },
-  {
-    "name": "fast-forward",
-    "terms": ["skip", "next", "speed up"],
-    "category": "Media"
-  },
-  {
-    "name": "begin",
-    "terms": ["start", "rewind", "previous", "back"],
-    "category": "Media"
-  },
-  {
-    "name": "end",
-    "terms": ["next", "skip", "forward"],
-    "category": "Media"
-  },
-  {
-    "name": "shuffle",
-    "terms": ["random"],
-    "category": "Media"
-  },
-  {
-    "name": "repeat",
-    "terms": ["again", "replay", "rerun"],
-    "category": "Media"
-  },
-  {
-    "name": "eject",
-    "terms": ["discharge", "release", "expel"],
-    "category": "Media"
-  },
-  {
-    "name": "media-filled",
-    "category": "Media"
-  },
-  {
-    "name": "multimedia-filled",
-    "category": "Media"
-  },
+  { "name": "audio", "terms": ["sound", "acoustic", "music", "musical note"], "category": "Media" },
+  { "name": "audio-wave", "terms": ["sound", "acoustic", "music", "audio"], "category": "Media" },
+  { "name": "video", "terms": ["movie", "film", "recording"], "category": "Media" },
+  { "name": "video-off", "terms": ["movie", "film", "recording"], "category": "Media" },
+  { "name": "voice", "terms": ["microphone", "recording"], "category": "Media" },
+  { "name": "voice-off", "terms": ["microphone", "recording"], "category": "Media" },
+  { "name": "sound-on", "terms": ["audio", "acoustic"], "category": "Media" },
+  { "name": "sound-off", "terms": ["audio", "acoustic", "silent"], "category": "Media" },
+  { "name": "sound-mute", "terms": ["audio", "acoustic", "silent"], "category": "Media" },
+  { "name": "play", "terms": ["start", "resume", "continue"], "category": "Media" },
+  { "name": "pause", "terms": ["stop", "break", "halt"], "category": "Media" },
+  { "name": "record", "terms": ["register", "enroll"], "category": "Media" },
+  { "name": "stop", "terms": ["halt", "end"], "category": "Media" },
+  { "name": "recording", "category": "Media" },
+  { "name": "fast-rewind", "terms": ["last", "back", "reverse"], "category": "Media" },
+  { "name": "fast-forward", "terms": ["skip", "next", "speed up"], "category": "Media" },
+  { "name": "begin", "terms": ["start", "rewind", "previous", "back"], "category": "Media" },
+  { "name": "end", "terms": ["next", "skip", "forward"], "category": "Media" },
+  { "name": "shuffle", "terms": ["random"], "category": "Media" },
+  { "name": "repeat", "terms": ["again", "replay", "rerun"], "category": "Media" },
+  { "name": "eject", "terms": ["discharge", "release", "expel"], "category": "Media" },
+  { "name": "media-filled", "category": "Media" },
+  { "name": "multimedia-filled", "category": "Media" },
   {
     "name": "av-system-filled",
     "terms": ["audio visual", "speaker", "sound", "acoustic", "screen"],
@@ -2048,86 +720,22 @@
     "terms": ["sound", "acoustic", "music", "musical note"],
     "category": "Media"
   },
-  {
-    "name": "video-filled",
-    "terms": ["movie", "film", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "video-off-filled",
-    "terms": ["movie", "film", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "voice-filled",
-    "terms": ["microphone", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "voice-off-filled",
-    "terms": ["microphone", "recording"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-on-filled",
-    "terms": ["audio", "acoustic"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-off-filled",
-    "terms": ["audio", "acoustic", "silent"],
-    "category": "Media"
-  },
-  {
-    "name": "sound-mute-filled",
-    "terms": ["audio", "acoustic", "silent"],
-    "category": "Media"
-  },
-  {
-    "name": "play-filled",
-    "terms": ["start", "resume", "continue"],
-    "category": "Media"
-  },
-  {
-    "name": "pause-filled",
-    "terms": ["stop", "break", "halt"],
-    "category": "Media"
-  },
-  {
-    "name": "record-filled",
-    "terms": ["register", "enroll"],
-    "category": "Media"
-  },
-  {
-    "name": "stop-filled",
-    "terms": ["halt", "end"],
-    "category": "Media"
-  },
-  {
-    "name": "fast-rewind-filled",
-    "terms": ["last", "back", "reverse"],
-    "category": "Media"
-  },
-  {
-    "name": "fast-forward-filled",
-    "terms": ["skip", "next", "speed up"],
-    "category": "Media"
-  },
-  {
-    "name": "begin-filled",
-    "terms": ["start", "rewind", "previous", "back"],
-    "category": "Media"
-  },
-  {
-    "name": "end-filled",
-    "terms": ["next", "skip", "forward"],
-    "category": "Media"
-  },
-  {
-    "name": "eject-filled",
-    "terms": ["discharge", "release", "expel"],
-    "category": "Media"
-  },
+  { "name": "video-filled", "terms": ["movie", "film", "recording"], "category": "Media" },
+  { "name": "video-off-filled", "terms": ["movie", "film", "recording"], "category": "Media" },
+  { "name": "voice-filled", "terms": ["microphone", "recording"], "category": "Media" },
+  { "name": "voice-off-filled", "terms": ["microphone", "recording"], "category": "Media" },
+  { "name": "sound-on-filled", "terms": ["audio", "acoustic"], "category": "Media" },
+  { "name": "sound-off-filled", "terms": ["audio", "acoustic", "silent"], "category": "Media" },
+  { "name": "sound-mute-filled", "terms": ["audio", "acoustic", "silent"], "category": "Media" },
+  { "name": "play-filled", "terms": ["start", "resume", "continue"], "category": "Media" },
+  { "name": "pause-filled", "terms": ["stop", "break", "halt"], "category": "Media" },
+  { "name": "record-filled", "terms": ["register", "enroll"], "category": "Media" },
+  { "name": "stop-filled", "terms": ["halt", "end"], "category": "Media" },
+  { "name": "fast-rewind-filled", "terms": ["last", "back", "reverse"], "category": "Media" },
+  { "name": "fast-forward-filled", "terms": ["skip", "next", "speed up"], "category": "Media" },
+  { "name": "begin-filled", "terms": ["start", "rewind", "previous", "back"], "category": "Media" },
+  { "name": "end-filled", "terms": ["next", "skip", "forward"], "category": "Media" },
+  { "name": "eject-filled", "terms": ["discharge", "release", "expel"], "category": "Media" },
   {
     "name": "user",
     "terms": ["person", "profile", "account", "customer", "consumer"],
@@ -2138,16 +746,8 @@
     "terms": ["person", "profile", "account", "customer", "consumer"],
     "category": "User"
   },
-  {
-    "name": "account",
-    "terms": ["person", "profile", "user"],
-    "category": "User"
-  },
-  {
-    "name": "badge",
-    "terms": ["identification"],
-    "category": "User"
-  },
+  { "name": "account", "terms": ["person", "profile", "user"], "category": "User" },
+  { "name": "badge", "terms": ["identification"], "category": "User" },
   {
     "name": "registration",
     "terms": ["identification", "documentation", "listing", "enrollment"],
@@ -2173,10 +773,7 @@
     "terms": ["designer", "planner", "builder", "architect"],
     "category": "User"
   },
-  {
-    "name": "chimney-sweeper",
-    "category": "User"
-  },
+  { "name": "chimney-sweeper", "category": "User" },
   {
     "name": "support",
     "terms": ["help", "guidance", "assistance", "aid", "guide"],
@@ -2207,16 +804,8 @@
     "terms": ["person", "profile", "account", "customer", "consumer", "initialize", "initiate"],
     "category": "User"
   },
-  {
-    "name": "account-filled",
-    "terms": ["person", "profile", "user"],
-    "category": "User"
-  },
-  {
-    "name": "badge-filled",
-    "terms": ["identification"],
-    "category": "User"
-  },
+  { "name": "account-filled", "terms": ["person", "profile", "user"], "category": "User" },
+  { "name": "badge-filled", "terms": ["identification"], "category": "User" },
   {
     "name": "user-group-filled",
     "terms": ["customers", "consumers", "person", "people"],
@@ -2227,202 +816,60 @@
     "terms": ["customers", "consumers", "person", "people"],
     "category": "User"
   },
-  {
-    "name": "up-1",
-    "category": "Arrows"
-  },
-  {
-    "name": "down-1",
-    "category": "Arrows"
-  },
-  {
-    "name": "left-1",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "right-1",
-    "terms": ["forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "up-2",
-    "category": "Arrows"
-  },
-  {
-    "name": "down-2",
-    "category": "Arrows"
-  },
-  {
-    "name": "left-2",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "right-2",
-    "terms": ["forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "up-3",
-    "category": "Arrows"
-  },
-  {
-    "name": "down-3",
-    "category": "Arrows"
-  },
-  {
-    "name": "left-3",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "right-3",
-    "terms": ["forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "up-4",
-    "category": "Arrows"
-  },
-  {
-    "name": "down-4",
-    "category": "Arrows"
-  },
+  { "name": "up-1", "category": "Arrows" },
+  { "name": "down-1", "category": "Arrows" },
+  { "name": "left-1", "terms": ["backward"], "category": "Arrows" },
+  { "name": "right-1", "terms": ["forward"], "category": "Arrows" },
+  { "name": "up-2", "category": "Arrows" },
+  { "name": "down-2", "category": "Arrows" },
+  { "name": "left-2", "terms": ["backward"], "category": "Arrows" },
+  { "name": "right-2", "terms": ["forward"], "category": "Arrows" },
+  { "name": "up-3", "category": "Arrows" },
+  { "name": "down-3", "category": "Arrows" },
+  { "name": "left-3", "terms": ["backward"], "category": "Arrows" },
+  { "name": "right-3", "terms": ["forward"], "category": "Arrows" },
+  { "name": "up-4", "category": "Arrows" },
+  { "name": "down-4", "category": "Arrows" },
   { "name": "arrow-top-left", "category": "Arrows" },
   { "name": "arrow-top-right", "category": "Arrows" },
   { "name": "arrow-bottom-left", "category": "Arrows" },
   { "name": "arrow-bottom-right", "category": "Arrows" },
-  {
-    "name": "left-4",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "right-4",
-    "terms": ["forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "double-up",
-    "category": "Arrows"
-  },
-  {
-    "name": "double-down",
-    "category": "Arrows"
-  },
-  {
-    "name": "double-left",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "double-right",
-    "terms": ["skip", "forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "command-arrow",
-    "category": "Arrows"
-  },
-  {
-    "name": "command-open",
-    "category": "Arrows"
-  },
-  {
-    "name": "command-close",
-    "category": "Arrows"
-  },
-  {
-    "name": "breadcrumb-root",
-    "category": "Arrows"
-  },
-  {
-    "name": "up-1-filled",
-    "category": "Arrows"
-  },
-  {
-    "name": "down-1-filled",
-    "category": "Arrows"
-  },
-  {
-    "name": "left-1-filled",
-    "terms": ["backward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "right-1-filled",
-    "terms": ["forward"],
-    "category": "Arrows"
-  },
-  {
-    "name": "command-arrow-filled",
-    "category": "Arrows"
-  },
-  {
-    "name": "plus",
-    "terms": ["add", "append", "increase", "positive"],
-    "category": "Tools"
-  },
-  {
-    "name": "minus",
-    "terms": ["subtract", "remove", "decrease", "negative"],
-    "category": "Tools"
-  },
-  {
-    "name": "reply",
-    "terms": ["answer", "respond", "react", "left"],
-    "category": "Tools"
-  },
-  {
-    "name": "forward",
-    "terms": ["next", "right", "advance"],
-    "category": "Tools"
-  },
-  {
-    "name": "upload",
-    "category": "Tools"
-  },
-  {
-    "name": "download",
-    "terms": ["save"],
-    "category": "Tools"
-  },
-  {
-    "name": "brighter",
-    "terms": ["light", "sun", "shine"],
-    "category": "Tools"
-  },
-  {
-    "name": "darker",
-    "terms": ["light", "sun"],
-    "category": "Tools"
-  },
+  { "name": "left-4", "terms": ["backward"], "category": "Arrows" },
+  { "name": "right-4", "terms": ["forward"], "category": "Arrows" },
+  { "name": "double-up", "category": "Arrows" },
+  { "name": "double-down", "category": "Arrows" },
+  { "name": "double-left", "terms": ["backward"], "category": "Arrows" },
+  { "name": "double-right", "terms": ["skip", "forward"], "category": "Arrows" },
+  { "name": "command-arrow", "category": "Arrows" },
+  { "name": "command-open", "category": "Arrows" },
+  { "name": "command-close", "category": "Arrows" },
+  { "name": "breadcrumb-root", "category": "Arrows" },
+  { "name": "up-1-filled", "category": "Arrows" },
+  { "name": "down-1-filled", "category": "Arrows" },
+  { "name": "left-1-filled", "terms": ["backward"], "category": "Arrows" },
+  { "name": "right-1-filled", "terms": ["forward"], "category": "Arrows" },
+  { "name": "command-arrow-filled", "category": "Arrows" },
+  { "name": "plus", "terms": ["add", "append", "increase", "positive"], "category": "Tools" },
+  { "name": "minus", "terms": ["subtract", "remove", "decrease", "negative"], "category": "Tools" },
+  { "name": "reply", "terms": ["answer", "respond", "react", "left"], "category": "Tools" },
+  { "name": "forward", "terms": ["next", "right", "advance"], "category": "Tools" },
+  { "name": "upload", "category": "Tools" },
+  { "name": "download", "terms": ["save"], "category": "Tools" },
+  { "name": "brighter", "terms": ["light", "sun", "shine"], "category": "Tools" },
+  { "name": "darker", "terms": ["light", "sun"], "category": "Tools" },
   {
     "name": "zoom-in",
     "terms": ["focus", "scale", "bigger", "larger", "expand"],
     "category": "Tools"
   },
-  {
-    "name": "zoom-out",
-    "terms": ["focus", "scale", "smaller"],
-    "category": "Tools"
-  },
+  { "name": "zoom-out", "terms": ["focus", "scale", "smaller"], "category": "Tools" },
   {
     "name": "zoom-reset",
     "terms": ["center", "scale", "normalize", "default", "restore"],
     "category": "Tools"
   },
-  {
-    "name": "expand",
-    "terms": ["enlarge"],
-    "category": "Tools"
-  },
-  {
-    "name": "collapse",
-    "terms": ["reduce", "shrink"],
-    "category": "Tools"
-  },
+  { "name": "expand", "terms": ["enlarge"], "category": "Tools" },
+  { "name": "collapse", "terms": ["reduce", "shrink"], "category": "Tools" },
   {
     "name": "zoom",
     "terms": ["focus", "scale", "bigger", "larger", "expand"],
@@ -2433,11 +880,7 @@
     "terms": ["focus", "compress", "scale", "zoom", "smaller"],
     "category": "Tools"
   },
-  {
-    "name": "move",
-    "terms": ["navigate"],
-    "category": "Tools"
-  },
+  { "name": "move", "terms": ["navigate"], "category": "Tools" },
   {
     "name": "import",
     "terms": ["transport", "fetch", "bring", "incorporate"],
@@ -2453,36 +896,12 @@
     "terms": ["sign in", "access", "username", "password", "entry"],
     "category": "Tools"
   },
-  {
-    "name": "logout",
-    "terms": ["sign out", "disconnect", "exit"],
-    "category": "Tools"
-  },
-  {
-    "name": "backup",
-    "terms": ["saved", "history"],
-    "category": "Tools"
-  },
-  {
-    "name": "restore",
-    "terms": ["bring back", "repair", "mend"],
-    "category": "Tools"
-  },
-  {
-    "name": "undo",
-    "terms": ["back", "revert"],
-    "category": "Tools"
-  },
-  {
-    "name": "redo",
-    "terms": ["again", "repeat", "retry"],
-    "category": "Tools"
-  },
-  {
-    "name": "refresh",
-    "terms": ["update", "synchronize", "reload"],
-    "category": "Tools"
-  },
+  { "name": "logout", "terms": ["sign out", "disconnect", "exit"], "category": "Tools" },
+  { "name": "backup", "terms": ["saved", "history"], "category": "Tools" },
+  { "name": "restore", "terms": ["bring back", "repair", "mend"], "category": "Tools" },
+  { "name": "undo", "terms": ["back", "revert"], "category": "Tools" },
+  { "name": "redo", "terms": ["again", "repeat", "retry"], "category": "Tools" },
+  { "name": "refresh", "terms": ["update", "synchronize", "reload"], "category": "Tools" },
   {
     "name": "synchronize",
     "terms": ["harmonize", "conform", "align", "coordinate"],
@@ -2505,21 +924,9 @@
     ],
     "category": "Tools"
   },
-  {
-    "name": "cancel",
-    "terms": ["clear", "close", "discard", "erase", "bad"],
-    "category": "Tools"
-  },
-  {
-    "name": "edit",
-    "terms": ["change", "rewrite", "modify", "alter"],
-    "category": "Tools"
-  },
-  {
-    "name": "edit-bulk",
-    "terms": ["change", "rewrite", "modify", "alter"],
-    "category": "Tools"
-  },
+  { "name": "cancel", "terms": ["clear", "close", "discard", "erase", "bad"], "category": "Tools" },
+  { "name": "edit", "terms": ["change", "rewrite", "modify", "alter"], "category": "Tools" },
+  { "name": "edit-bulk", "terms": ["change", "rewrite", "modify", "alter"], "category": "Tools" },
   {
     "name": "notes-edit",
     "terms": ["comment", "entry", "change", "rewrite", "modify", "alter"],
@@ -2535,46 +942,22 @@
     "terms": ["link", "path", "change", "rewrite", "modify", "alter"],
     "category": "Tools"
   },
-  {
-    "name": "save",
-    "terms": ["store", "preserve"],
-    "category": "Tools"
-  },
+  { "name": "save", "terms": ["store", "preserve"], "category": "Tools" },
   {
     "name": "delete",
     "terms": ["bin", "trash", "garbage", "waste", "discard", "remove", "dispose"],
     "category": "Tools"
   },
-  {
-    "name": "copy",
-    "terms": ["duplicate", "replicate"],
-    "category": "Tools"
-  },
-  {
-    "name": "paste",
-    "terms": ["insert", "input"],
-    "category": "Tools"
-  },
-  {
-    "name": "paste-into",
-    "terms": ["insert", "input"],
-    "category": "Tools"
-  },
+  { "name": "copy", "terms": ["duplicate", "replicate"], "category": "Tools" },
+  { "name": "paste", "terms": ["insert", "input"], "category": "Tools" },
+  { "name": "paste-into", "terms": ["insert", "input"], "category": "Tools" },
   {
     "name": "cut",
     "terms": ["scissors", "remove", "delete", "erase", "trim", "snip"],
     "category": "Tools"
   },
-  {
-    "name": "return",
-    "terms": ["backward", "undo", "revert"],
-    "category": "Tools"
-  },
-  {
-    "name": "back",
-    "terms": ["return", "undo", "revert"],
-    "category": "Tools"
-  },
+  { "name": "return", "terms": ["backward", "undo", "revert"], "category": "Tools" },
+  { "name": "back", "terms": ["return", "undo", "revert"], "category": "Tools" },
   {
     "name": "warning",
     "terms": ["danger", "alert", "caution", "signal", "notice"],
@@ -2590,11 +973,7 @@
     "terms": ["alert", "error", "signal", "notice"],
     "category": "Tools"
   },
-  {
-    "name": "info",
-    "terms": ["details", "description", "explanation"],
-    "category": "Tools"
-  },
+  { "name": "info", "terms": ["details", "description", "explanation"], "category": "Tools" },
   {
     "name": "help",
     "terms": ["question mark", "support", "guidance", "aid", "assistance", "guide"],
@@ -2605,66 +984,26 @@
     "terms": ["support", "guidance", "aid", "assistance", "guide"],
     "category": "Tools"
   },
-  {
-    "name": "busy",
-    "terms": ["loading"],
-    "category": "Tools"
-  },
-  {
-    "name": "tag",
-    "terms": ["label", "mark", "description"],
-    "category": "Tools"
-  },
-  {
-    "name": "bookmark",
-    "category": "Tools"
-  },
-  {
-    "name": "mark",
-    "terms": ["flag", "important", "highlighted"],
-    "category": "Tools"
-  },
+  { "name": "busy", "terms": ["loading"], "category": "Tools" },
+  { "name": "tag", "terms": ["label", "mark", "description"], "category": "Tools" },
+  { "name": "bookmark", "category": "Tools" },
+  { "name": "mark", "terms": ["flag", "important", "highlighted"], "category": "Tools" },
   {
     "name": "prime",
     "terms": ["certificate", "award", "achievement", "honor", "recognition"],
     "category": "Tools"
   },
-  {
-    "name": "in-use",
-    "terms": ["occupied", "busy"],
-    "tags": ["occupied"],
-    "category": "Tools"
-  },
+  { "name": "in-use", "terms": ["occupied", "busy"], "tags": ["occupied"], "category": "Tools" },
   {
     "name": "search",
     "terms": ["magnifier", "magnifying glass", "find", "explore"],
     "category": "Tools"
   },
-  {
-    "name": "share",
-    "terms": ["send", "upload", "transmit"],
-    "category": "Tools"
-  },
-  {
-    "name": "share-alt",
-    "terms": ["send", "upload", "transmit"],
-    "category": "Tools"
-  },
-  {
-    "name": "send-to",
-    "terms": ["transmit"],
-    "category": "Tools"
-  },
-  {
-    "name": "pin",
-    "terms": ["fix", "attach", "secure", "highlight"],
-    "category": "Tools"
-  },
-  {
-    "name": "unpinned",
-    "terms": ["unfix", "detach", "unfasten"],
-    "category": "Tools"
-  },
+  { "name": "share", "terms": ["send", "upload", "transmit"], "category": "Tools" },
+  { "name": "share-alt", "terms": ["send", "upload", "transmit"], "category": "Tools" },
+  { "name": "send-to", "terms": ["transmit"], "category": "Tools" },
+  { "name": "pin", "terms": ["fix", "attach", "secure", "highlight"], "category": "Tools" },
+  { "name": "unpinned", "terms": ["unfix", "detach", "unfasten"], "category": "Tools" },
   {
     "name": "folder",
     "terms": ["directory", "file", "binder", "archive", "repository"],
@@ -2675,31 +1014,15 @@
     "terms": ["directory", "file", "binder", "archive", "repository"],
     "category": "Tools"
   },
-  {
-    "name": "archive",
-    "terms": ["registers", "records", "documentation"],
-    "category": "Tools"
-  },
-  {
-    "name": "document",
-    "terms": ["file", "paper"],
-    "category": "Tools"
-  },
+  { "name": "archive", "terms": ["registers", "records", "documentation"], "category": "Tools" },
+  { "name": "document", "terms": ["file", "paper"], "category": "Tools" },
   {
     "name": "documents",
     "terms": ["file", "version", "collection", "multiple", "group"],
     "category": "Tools"
   },
-  {
-    "name": "document-pdf",
-    "terms": ["file", "portable document format"],
-    "category": "Tools"
-  },
-  {
-    "name": "document-zip",
-    "terms": ["file", "data compression"],
-    "category": "Tools"
-  },
+  { "name": "document-pdf", "terms": ["file", "portable document format"], "category": "Tools" },
+  { "name": "document-zip", "terms": ["file", "data compression"], "category": "Tools" },
   { "name": "document-csv", "terms": ["file", "comma separated"], "category": "Tools" },
   {
     "name": "row-add",
@@ -2716,11 +1039,7 @@
     "terms": ["table", "line", "copy", "paste", "replicate"],
     "category": "Tools"
   },
-  {
-    "name": "row-move",
-    "terms": ["table", "line", "drag", "paste", "drop"],
-    "category": "Tools"
-  },
+  { "name": "row-move", "terms": ["table", "line", "drag", "paste", "drop"], "category": "Tools" },
   {
     "name": "column-move",
     "terms": ["table", "column", "drag", "paste", "drop"],
@@ -2742,87 +1061,28 @@
     "tags": ["eye"],
     "category": "Tools"
   },
-  {
-    "name": "hide",
-    "terms": ["invisible", "eye", "conceal", "mask"],
-    "category": "Tools"
-  },
-  {
-    "name": "sort-up",
-    "terms": ["order", "ascending", "rising"],
-    "category": "Tools"
-  },
-  {
-    "name": "sort-down",
-    "terms": ["order", "descending", "falling"],
-    "category": "Tools"
-  },
-  {
-    "name": "align-left",
-    "category": "Tools"
-  },
-  {
-    "name": "align-horizontal-centers",
-    "category": "Tools"
-  },
-  {
-    "name": "align-right",
-    "category": "Tools"
-  },
-  {
-    "name": "align-top",
-    "category": "Tools"
-  },
-  {
-    "name": "align-vertical-centers",
-    "category": "Tools"
-  },
-  {
-    "name": "align-bottom",
-    "category": "Tools"
-  },
-  {
-    "name": "align-center",
-    "category": "Tools"
-  },
-  {
-    "name": "expand-all",
-    "terms": ["show", "reveal"],
-    "category": "Tools"
-  },
-  {
-    "name": "collapse-all",
-    "terms": ["hide", "conceal"],
-    "category": "Tools"
-  },
-  {
-    "name": "angle",
-    "category": "Tools"
-  },
-  {
-    "name": "height",
-    "terms": ["altitude", "length"],
-    "category": "Tools"
-  },
-  {
-    "name": "ruler",
-    "category": "Tools"
-  },
-  {
-    "name": "convert",
-    "terms": ["change", "transform"],
-    "category": "Tools"
-  },
+  { "name": "hide", "terms": ["invisible", "eye", "conceal", "mask"], "category": "Tools" },
+  { "name": "sort-up", "terms": ["order", "ascending", "rising"], "category": "Tools" },
+  { "name": "sort-down", "terms": ["order", "descending", "falling"], "category": "Tools" },
+  { "name": "align-left", "category": "Tools" },
+  { "name": "align-horizontal-centers", "category": "Tools" },
+  { "name": "align-right", "category": "Tools" },
+  { "name": "align-top", "category": "Tools" },
+  { "name": "align-vertical-centers", "category": "Tools" },
+  { "name": "align-bottom", "category": "Tools" },
+  { "name": "align-center", "category": "Tools" },
+  { "name": "expand-all", "terms": ["show", "reveal"], "category": "Tools" },
+  { "name": "collapse-all", "terms": ["hide", "conceal"], "category": "Tools" },
+  { "name": "angle", "category": "Tools" },
+  { "name": "height", "terms": ["altitude", "length"], "category": "Tools" },
+  { "name": "ruler", "category": "Tools" },
+  { "name": "convert", "terms": ["change", "transform"], "category": "Tools" },
   {
     "name": "online-configuration",
     "terms": ["arrangement", "layout", "structure"],
     "category": "Tools"
   },
-  {
-    "name": "room-3d",
-    "terms": ["three-dimensional"],
-    "category": "Tools"
-  },
+  { "name": "room-3d", "terms": ["three-dimensional"], "category": "Tools" },
   {
     "name": "interpolation-linear",
     "terms": ["statistics", "trend", "prediction", "analysis"],
@@ -2838,31 +1098,15 @@
     "terms": ["statistics", "trend", "prediction", "analysis"],
     "category": "Tools"
   },
-  {
-    "name": "reply-filled",
-    "terms": ["answer", "respond", "react", "left"],
-    "category": "Tools"
-  },
-  {
-    "name": "forward-filled",
-    "terms": ["next", "right", "advance"],
-    "category": "Tools"
-  },
-  {
-    "name": "ok-filled",
-    "terms": ["successful", "tick", "good", "apply"],
-    "category": "Tools"
-  },
+  { "name": "reply-filled", "terms": ["answer", "respond", "react", "left"], "category": "Tools" },
+  { "name": "forward-filled", "terms": ["next", "right", "advance"], "category": "Tools" },
+  { "name": "ok-filled", "terms": ["successful", "tick", "good", "apply"], "category": "Tools" },
   {
     "name": "cancel-filled",
     "terms": ["clear", "close", "discard", "erase", "bad"],
     "category": "Tools"
   },
-  {
-    "name": "edit-filled",
-    "terms": ["change", "rewrite", "modify", "alter"],
-    "category": "Tools"
-  },
+  { "name": "edit-filled", "terms": ["change", "rewrite", "modify", "alter"], "category": "Tools" },
   {
     "name": "delete-filled",
     "terms": ["bin", "trash", "garbage", "waste", "discard", "remove", "dispose"],
@@ -2893,49 +1137,19 @@
     "terms": ["question mark", "support", "guidance", "aid", "assistance", "guide"],
     "category": "Tools"
   },
-  {
-    "name": "tag-filled",
-    "terms": ["label", "mark", "description"],
-    "category": "Tools"
-  },
-  {
-    "name": "bookmark-filled",
-    "category": "Tools"
-  },
-  {
-    "name": "pill-filled",
-    "category": "Tools"
-  },
-  {
-    "name": "mark-filled",
-    "terms": ["flag", "important", "highlighted"],
-    "category": "Tools"
-  },
+  { "name": "tag-filled", "terms": ["label", "mark", "description"], "category": "Tools" },
+  { "name": "bookmark-filled", "category": "Tools" },
+  { "name": "pill-filled", "category": "Tools" },
+  { "name": "mark-filled", "terms": ["flag", "important", "highlighted"], "category": "Tools" },
   {
     "name": "prime-filled",
     "terms": ["certificate", "award", "achievement", "honor", "recognition"],
     "category": "Tools"
   },
-  {
-    "name": "share-filled",
-    "terms": ["send", "upload", "transmit"],
-    "category": "Tools"
-  },
-  {
-    "name": "send-to-filled",
-    "terms": ["transmit"],
-    "category": "Tools"
-  },
-  {
-    "name": "pin-filled",
-    "terms": ["fix", "attach", "secure", "highlight"],
-    "category": "Tools"
-  },
-  {
-    "name": "unpinned-filled",
-    "terms": ["unfix", "detach", "unfasten"],
-    "category": "Tools"
-  },
+  { "name": "share-filled", "terms": ["send", "upload", "transmit"], "category": "Tools" },
+  { "name": "send-to-filled", "terms": ["transmit"], "category": "Tools" },
+  { "name": "pin-filled", "terms": ["fix", "attach", "secure", "highlight"], "category": "Tools" },
+  { "name": "unpinned-filled", "terms": ["unfix", "detach", "unfasten"], "category": "Tools" },
   {
     "name": "folder-filled",
     "terms": ["directory", "file", "binder", "archive", "repository"],
@@ -2951,11 +1165,7 @@
     "terms": ["registers", "records", "documentation"],
     "category": "Tools"
   },
-  {
-    "name": "document-filled",
-    "terms": ["file", "paper"],
-    "category": "Tools"
-  },
+  { "name": "document-filled", "terms": ["file", "paper"], "category": "Tools" },
   {
     "name": "mail-filled",
     "terms": ["messages", "text", "communication", "post", "envelope", "inbox", "letter"],
@@ -2967,16 +1177,8 @@
     "tags": ["surveillance"],
     "category": "Tools"
   },
-  {
-    "name": "hide-filled",
-    "terms": ["invisible", "eye", "conceal", "mask"],
-    "category": "Tools"
-  },
-  {
-    "name": "room-3d-filled",
-    "terms": ["three-dimensional"],
-    "category": "Tools"
-  },
+  { "name": "hide-filled", "terms": ["invisible", "eye", "conceal", "mask"], "category": "Tools" },
+  { "name": "room-3d-filled", "terms": ["three-dimensional"], "category": "Tools" },
   {
     "name": "row-move-filled",
     "terms": ["table", "line", "drag", "paste", "drop"],
@@ -2987,207 +1189,76 @@
     "terms": ["table", "column", "drag", "paste", "drop"],
     "category": "Tools"
   },
-  {
-    "name": "location",
-    "terms": ["position", "place"],
-    "category": "Map"
-  },
-  {
-    "name": "geofence",
-    "terms": ["position", "place", "perimeter"],
-    "category": "Map"
-  },
-  {
-    "name": "map-location",
-    "terms": ["position", "place", "chart"],
-    "category": "Map"
-  },
+  { "name": "location", "terms": ["position", "place"], "category": "Map" },
+  { "name": "geofence", "terms": ["position", "place", "perimeter"], "category": "Map" },
+  { "name": "map-location", "terms": ["position", "place", "chart"], "category": "Map" },
   {
     "name": "change-location",
     "terms": ["alter", "edit", "modify", "position", "place"],
     "category": "Map"
   },
-  {
-    "name": "map-arrow",
-    "terms": ["paper airplane", "chart"],
-    "category": "Map"
-  },
-  {
-    "name": "map-arrow-not-available",
-    "terms": ["paper airplane", "chart"],
-    "category": "Map"
-  },
-  {
-    "name": "locate",
-    "terms": ["position", "place"],
-    "category": "Map"
-  },
-  {
-    "name": "distance",
-    "terms": ["span"],
-    "category": "Map"
-  },
+  { "name": "map-arrow", "terms": ["paper airplane", "chart"], "category": "Map" },
+  { "name": "map-arrow-not-available", "terms": ["paper airplane", "chart"], "category": "Map" },
+  { "name": "locate", "terms": ["position", "place"], "category": "Map" },
+  { "name": "distance", "terms": ["span"], "category": "Map" },
   {
     "name": "go-to",
     "terms": ["navigation", "directions", "position", "place"],
     "category": "Map"
   },
-  {
-    "name": "compass-needle",
-    "terms": ["directions", "navigation"],
-    "category": "Map"
-  },
-  {
-    "name": "location-filled",
-    "terms": ["position", "place"],
-    "category": "Map"
-  },
-  {
-    "name": "geofence-filled",
-    "terms": ["position", "place", "perimeter"],
-    "category": "Map"
-  },
-  {
-    "name": "map-location-filled",
-    "terms": ["position", "place", "chart"],
-    "category": "Map"
-  },
-  {
-    "name": "map-arrow-filled",
-    "terms": ["paper airplane", "chart"],
-    "category": "Map"
-  },
-  {
-    "name": "fire",
-    "terms": ["flame", "burn", "heat", "blaze"],
-    "category": "Fire"
-  },
+  { "name": "compass-needle", "terms": ["directions", "navigation"], "category": "Map" },
+  { "name": "location-filled", "terms": ["position", "place"], "category": "Map" },
+  { "name": "geofence-filled", "terms": ["position", "place", "perimeter"], "category": "Map" },
+  { "name": "map-location-filled", "terms": ["position", "place", "chart"], "category": "Map" },
+  { "name": "map-arrow-filled", "terms": ["paper airplane", "chart"], "category": "Map" },
+  { "name": "fire", "terms": ["flame", "burn", "heat", "blaze"], "category": "Fire" },
   {
     "name": "mass-notification",
     "terms": ["alarm", "alert", "signal", "warning", "siren", "caution"],
     "category": "Fire"
   },
-  {
-    "name": "megaphone",
-    "terms": ["speaker"],
-    "category": "Fire"
-  },
+  { "name": "megaphone", "terms": ["speaker"], "category": "Fire" },
   {
     "name": "security-cam",
     "terms": ["camera", "footage", "video", "tapes", "recording"],
     "category": "Fire"
   },
-  {
-    "name": "fire-sensor",
-    "terms": ["smoke detection", "fire alarm"],
-    "category": "Fire"
-  },
+  { "name": "fire-sensor", "terms": ["smoke detection", "fire alarm"], "category": "Fire" },
   { "name": "fire-sensor-alt", "terms": ["smoke detection", "fire alarm"], "category": "Fire" },
   {
     "name": "detector-sound-plate",
     "terms": ["smoke detection", "fire alarm"],
     "category": "Fire"
   },
-  {
-    "name": "combined-signal",
-    "terms": ["visual alarm", "audio alarm"],
-    "category": "Fire"
-  },
-  {
-    "name": "flame-detector",
-    "terms": ["smoke detection", "fire alarm"],
-    "category": "Fire"
-  },
-  {
-    "name": "beam-smoke-detector",
-    "terms": ["smoke detection", "fire alarm"],
-    "category": "Fire"
-  },
-  {
-    "name": "extinguishing",
-    "terms": ["fire", "blaze"],
-    "category": "Fire"
-  },
+  { "name": "combined-signal", "terms": ["visual alarm", "audio alarm"], "category": "Fire" },
+  { "name": "flame-detector", "terms": ["smoke detection", "fire alarm"], "category": "Fire" },
+  { "name": "beam-smoke-detector", "terms": ["smoke detection", "fire alarm"], "category": "Fire" },
+  { "name": "extinguishing", "terms": ["fire", "blaze"], "category": "Fire" },
   {
     "name": "manual-fire-sensor",
     "terms": ["smoke detection", "fire alarm", "hand"],
     "category": "Fire"
   },
-  {
-    "name": "intrusion-sensor",
-    "terms": ["invasion alarm", "trespass alert"],
-    "category": "Fire"
-  },
-  {
-    "name": "burglary",
-    "terms": ["burglary"],
-    "category": "Fire"
-  },
-  {
-    "name": "activation",
-    "terms": ["initialization"],
-    "category": "Fire"
-  },
-  {
-    "name": "fault",
-    "terms": ["flaw", "defect", "failing", "error"],
-    "category": "Fire"
-  },
-  {
-    "name": "exclamation-mark",
-    "terms": ["warning", "danger", "caution"],
-    "category": "Fire"
-  },
-  {
-    "name": "alarm-gas",
-    "category": "Fire"
-  },
-  {
-    "name": "pollution",
-    "terms": ["contamination", "dirt"],
-    "category": "Fire"
-  },
-  {
-    "name": "dust",
-    "terms": ["dirt"],
-    "category": "Fire"
-  },
-  {
-    "name": "testplan",
-    "terms": ["trial plan", "experiment plan"],
-    "category": "Fire"
-  },
+  { "name": "intrusion-sensor", "terms": ["invasion alarm", "trespass alert"], "category": "Fire" },
+  { "name": "burglary", "terms": ["burglary"], "category": "Fire" },
+  { "name": "activation", "terms": ["initialization"], "category": "Fire" },
+  { "name": "fault", "terms": ["flaw", "defect", "failing", "error"], "category": "Fire" },
+  { "name": "exclamation-mark", "terms": ["warning", "danger", "caution"], "category": "Fire" },
+  { "name": "alarm-gas", "category": "Fire" },
+  { "name": "pollution", "terms": ["contamination", "dirt"], "category": "Fire" },
+  { "name": "dust", "terms": ["dirt"], "category": "Fire" },
+  { "name": "testplan", "terms": ["trial plan", "experiment plan"], "category": "Fire" },
   {
     "name": "self-test",
     "terms": ["trial plan", "experiment plan", "individual"],
     "category": "Fire"
   },
-  {
-    "name": "fire-panel-alt",
-    "category": "Fire"
-  },
-  {
-    "name": "fire-panel",
-    "terms": ["ASD"],
-    "category": "Fire"
-  },
-  {
-    "name": "extension-board",
-    "category": "Fire"
-  },
-  {
-    "name": "topology-line",
-    "category": "Fire"
-  },
-  {
-    "name": "topology-stub",
-    "category": "Fire"
-  },
-  {
-    "name": "task-due",
-    "terms": ["deadlines", "schedule"],
-    "category": "Fire"
-  },
+  { "name": "fire-panel-alt", "category": "Fire" },
+  { "name": "fire-panel", "terms": ["ASD"], "category": "Fire" },
+  { "name": "extension-board", "category": "Fire" },
+  { "name": "topology-line", "category": "Fire" },
+  { "name": "topology-stub", "category": "Fire" },
+  { "name": "task-due", "terms": ["deadlines", "schedule"], "category": "Fire" },
   { "name": "list-warning", "category": "Fire" },
   {
     "name": "text-to-speech",
@@ -3214,16 +1285,8 @@
     "terms": ["detector examiner", "sensor validator"],
     "category": "Fire"
   },
-  {
-    "name": "fire-filled",
-    "terms": ["flame", "burn", "heat", "blaze"],
-    "category": "Fire"
-  },
-  {
-    "name": "megaphone-filled",
-    "terms": ["speaker"],
-    "category": "Fire"
-  },
+  { "name": "fire-filled", "terms": ["flame", "burn", "heat", "blaze"], "category": "Fire" },
+  { "name": "megaphone-filled", "terms": ["speaker"], "category": "Fire" },
   {
     "name": "security-cam-filled",
     "terms": ["camera", "footage", "video", "tapes", "recording"],
@@ -3244,11 +1307,7 @@
     "terms": ["detector examiner", "sensor validator"],
     "category": "Fire"
   },
-  {
-    "name": "power",
-    "terms": ["lightning", "electricity", "energy"],
-    "category": "Electricity"
-  },
+  { "name": "power", "terms": ["lightning", "electricity", "energy"], "category": "Electricity" },
   {
     "name": "wind-power",
     "terms": ["turbine", "electricity", "energy"],
@@ -3307,185 +1366,48 @@
     "terms": ["power network", "power distribution", "converter"],
     "category": "Electricity"
   },
-  {
-    "name": "motor",
-    "terms": ["engine"],
-    "category": "Electricity"
-  },
-  {
-    "name": "generator",
-    "category": "Electricity"
-  },
-  {
-    "name": "resistor",
-    "category": "Electricity"
-  },
-  {
-    "name": "fuse",
-    "terms": ["circuit breaker"],
-    "category": "Electricity"
-  },
-  {
-    "name": "inductor",
-    "terms": ["coil"],
-    "category": "Electricity"
-  },
-  {
-    "name": "capacitor",
-    "category": "Electricity"
-  },
-  {
-    "name": "feeder",
-    "terms": ["supplier"],
-    "category": "Electricity"
-  },
-  {
-    "name": "feeder-in",
-    "terms": ["supplier"],
-    "category": "Electricity"
-  },
-  {
-    "name": "feeder-out",
-    "terms": ["supplier"],
-    "category": "Electricity"
-  },
-  {
-    "name": "feeder-bidirection",
-    "terms": ["supplier"],
-    "category": "Electricity"
-  },
-  {
-    "name": "switchgear",
-    "terms": ["switchboard"],
-    "category": "Electricity"
-  },
+  { "name": "motor", "terms": ["engine"], "category": "Electricity" },
+  { "name": "generator", "category": "Electricity" },
+  { "name": "resistor", "category": "Electricity" },
+  { "name": "fuse", "terms": ["circuit breaker"], "category": "Electricity" },
+  { "name": "inductor", "terms": ["coil"], "category": "Electricity" },
+  { "name": "capacitor", "category": "Electricity" },
+  { "name": "feeder", "terms": ["supplier"], "category": "Electricity" },
+  { "name": "feeder-in", "terms": ["supplier"], "category": "Electricity" },
+  { "name": "feeder-out", "terms": ["supplier"], "category": "Electricity" },
+  { "name": "feeder-bidirection", "terms": ["supplier"], "category": "Electricity" },
+  { "name": "switchgear", "terms": ["switchboard"], "category": "Electricity" },
   {
     "name": "counter",
     "terms": ["energy meter", "electricity meter", "kilo watt hours"],
     "category": "Electricity"
   },
-  {
-    "name": "watt",
-    "terms": ["power meter"],
-    "tags": ["power-meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "volt",
-    "terms": ["voltage meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "ampere",
-    "terms": ["current meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "volt-ampere",
-    "terms": ["power meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "volt-ampere-reactive",
-    "terms": ["power meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "frequency",
-    "terms": ["hertz", "meter"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery",
-    "terms": ["accumulator", "full"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-medium",
-    "terms": ["accumulator", "sufficient"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-low",
-    "terms": ["accumulator", "depleted"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-empty",
-    "terms": ["accumulator", "discharged"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-charge",
-    "terms": ["accumulator"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-discharge",
-    "terms": ["accumulator", "usage"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-storage",
-    "terms": ["bess"],
-    "category": "Electricity"
-  },
-  {
-    "name": "battery-swap",
-    "category": "Electricity"
-  },
-  {
-    "name": "socket-ch",
-    "terms": ["outlet", "switzerland", "swiss"],
-    "category": "Electricity"
-  },
-  {
-    "name": "socket-eu",
-    "terms": ["outlet", "europe", "european"],
-    "category": "Electricity"
-  },
-  {
-    "name": "socket-cn",
-    "terms": ["outlet", "china", "chinese"],
-    "category": "Electricity"
-  },
-  {
-    "name": "ground-connection",
-    "terms": ["neutral"],
-    "category": "Electricity"
-  },
-  {
-    "name": "delta-circuit",
-    "category": "Electricity"
-  },
-  {
-    "name": "star-circuit",
-    "category": "Electricity"
-  },
-  {
-    "name": "open-circuit",
-    "category": "Electricity"
-  },
-  {
-    "name": "short-circuit",
-    "category": "Electricity"
-  },
-  {
-    "name": "inductor-primary-iso",
-    "category": "Electricity"
-  },
-  {
-    "name": "inductor-secondary-iso",
-    "category": "Electricity"
-  },
-  {
-    "name": "inductor-primary-ansi",
-    "category": "Electricity"
-  },
-  {
-    "name": "inductor-secondary-ansi",
-    "category": "Electricity"
-  },
+  { "name": "watt", "terms": ["power meter"], "tags": ["power-meter"], "category": "Electricity" },
+  { "name": "volt", "terms": ["voltage meter"], "category": "Electricity" },
+  { "name": "ampere", "terms": ["current meter"], "category": "Electricity" },
+  { "name": "volt-ampere", "terms": ["power meter"], "category": "Electricity" },
+  { "name": "volt-ampere-reactive", "terms": ["power meter"], "category": "Electricity" },
+  { "name": "frequency", "terms": ["hertz", "meter"], "category": "Electricity" },
+  { "name": "battery", "terms": ["accumulator", "full"], "category": "Electricity" },
+  { "name": "battery-medium", "terms": ["accumulator", "sufficient"], "category": "Electricity" },
+  { "name": "battery-low", "terms": ["accumulator", "depleted"], "category": "Electricity" },
+  { "name": "battery-empty", "terms": ["accumulator", "discharged"], "category": "Electricity" },
+  { "name": "battery-charge", "terms": ["accumulator"], "category": "Electricity" },
+  { "name": "battery-discharge", "terms": ["accumulator", "usage"], "category": "Electricity" },
+  { "name": "battery-storage", "terms": ["bess"], "category": "Electricity" },
+  { "name": "battery-swap", "category": "Electricity" },
+  { "name": "socket-ch", "terms": ["outlet", "switzerland", "swiss"], "category": "Electricity" },
+  { "name": "socket-eu", "terms": ["outlet", "europe", "european"], "category": "Electricity" },
+  { "name": "socket-cn", "terms": ["outlet", "china", "chinese"], "category": "Electricity" },
+  { "name": "ground-connection", "terms": ["neutral"], "category": "Electricity" },
+  { "name": "delta-circuit", "category": "Electricity" },
+  { "name": "star-circuit", "category": "Electricity" },
+  { "name": "open-circuit", "category": "Electricity" },
+  { "name": "short-circuit", "category": "Electricity" },
+  { "name": "inductor-primary-iso", "category": "Electricity" },
+  { "name": "inductor-secondary-iso", "category": "Electricity" },
+  { "name": "inductor-primary-ansi", "category": "Electricity" },
+  { "name": "inductor-secondary-ansi", "category": "Electricity" },
   {
     "name": "charging-station",
     "terms": ["charging base", "charging point"],
@@ -3506,58 +1428,19 @@
     "terms": ["charging base", "charging point"],
     "category": "Electricity"
   },
-  {
-    "name": "electric-car",
-    "category": "Electricity"
-  },
-  {
-    "name": "electric-car-off",
-    "category": "Electricity"
-  },
-  {
-    "name": "electric-truck",
-    "category": "Electricity"
-  },
-  {
-    "name": "electric-truck-off",
-    "category": "Electricity"
-  },
-  {
-    "name": "contact",
-    "category": "Electricity"
-  },
-  {
-    "name": "contact-closed",
-    "category": "Electricity"
-  },
-  {
-    "name": "circuit-breaker",
-    "category": "Electricity"
-  },
-  {
-    "name": "disconnector",
-    "category": "Electricity"
-  },
-  {
-    "name": "load-disconnector",
-    "category": "Electricity"
-  },
-  {
-    "name": "phasor-management-unit",
-    "category": "Electricity"
-  },
-  {
-    "name": "tapchanger",
-    "category": "Electricity"
-  },
-  {
-    "name": "busbar",
-    "category": "Electricity"
-  },
-  {
-    "name": "busbar-hsbt",
-    "category": "Electricity"
-  },
+  { "name": "electric-car", "category": "Electricity" },
+  { "name": "electric-car-off", "category": "Electricity" },
+  { "name": "electric-truck", "category": "Electricity" },
+  { "name": "electric-truck-off", "category": "Electricity" },
+  { "name": "contact", "category": "Electricity" },
+  { "name": "contact-closed", "category": "Electricity" },
+  { "name": "circuit-breaker", "category": "Electricity" },
+  { "name": "disconnector", "category": "Electricity" },
+  { "name": "load-disconnector", "category": "Electricity" },
+  { "name": "phasor-management-unit", "category": "Electricity" },
+  { "name": "tapchanger", "category": "Electricity" },
+  { "name": "busbar", "category": "Electricity" },
+  { "name": "busbar-hsbt", "category": "Electricity" },
   { "name": "converter", "category": "Electricity" },
   { "name": "inverter", "category": "Electricity" },
   { "name": "hybrid-inverter", "category": "Electricity" },
@@ -3566,11 +1449,7 @@
     "terms": ["lightning", "electricity", "energy"],
     "category": "Electricity"
   },
-  {
-    "name": "battery-filled",
-    "terms": ["accumulator", "full"],
-    "category": "Electricity"
-  },
+  { "name": "battery-filled", "terms": ["accumulator", "full"], "category": "Electricity" },
   {
     "name": "socket-ch-filled",
     "terms": ["outlet", "switzerland", "swiss"],
@@ -3591,43 +1470,14 @@
     "terms": ["charging base", "charging point"],
     "category": "Electricity"
   },
-  {
-    "name": "project",
-    "terms": ["plan"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "building",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "building-automation",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "smart-home",
-    "terms": ["automation"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "smart-home-alt",
-    "terms": ["automation"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "floor",
-    "terms": ["level"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "room",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "room-segment",
-    "terms": ["room section"],
-    "category": "Building Technologies"
-  },
+  { "name": "project", "terms": ["plan"], "category": "Building Technologies" },
+  { "name": "building", "category": "Building Technologies" },
+  { "name": "building-automation", "category": "Building Technologies" },
+  { "name": "smart-home", "terms": ["automation"], "category": "Building Technologies" },
+  { "name": "smart-home-alt", "terms": ["automation"], "category": "Building Technologies" },
+  { "name": "floor", "terms": ["level"], "category": "Building Technologies" },
+  { "name": "room", "category": "Building Technologies" },
+  { "name": "room-segment", "terms": ["room section"], "category": "Building Technologies" },
   { "name": "room-coordinator", "category": "Building Technologies" },
   { "name": "room-equipment", "category": "Building Technologies" },
   {
@@ -3635,60 +1485,20 @@
     "terms": ["segment", "area", "partition", "division"],
     "category": "Building Technologies"
   },
-  {
-    "name": "ahu-plant",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "automation-station",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "actuator",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "valve",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "fancoil",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "central-ahu",
-    "terms": ["air handling unit"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "compact-ahu",
-    "terms": ["air handling unit"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "vav-box",
-    "terms": ["variable air volume"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "heat-pump",
-    "category": "Building Technologies"
-  },
+  { "name": "ahu-plant", "category": "Building Technologies" },
+  { "name": "automation-station", "category": "Building Technologies" },
+  { "name": "actuator", "category": "Building Technologies" },
+  { "name": "valve", "category": "Building Technologies" },
+  { "name": "fancoil", "category": "Building Technologies" },
+  { "name": "central-ahu", "terms": ["air handling unit"], "category": "Building Technologies" },
+  { "name": "compact-ahu", "terms": ["air handling unit"], "category": "Building Technologies" },
+  { "name": "vav-box", "terms": ["variable air volume"], "category": "Building Technologies" },
+  { "name": "heat-pump", "category": "Building Technologies" },
   { "name": "heat-exchanger", "category": "Building Technologies" },
   { "name": "cooling-tower", "category": "Building Technologies" },
-  {
-    "name": "floor-heating",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "floor-heating-alt",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "vrf",
-    "terms": ["variable refrigerant flow"],
-    "category": "Building Technologies"
-  },
+  { "name": "floor-heating", "category": "Building Technologies" },
+  { "name": "floor-heating-alt", "category": "Building Technologies" },
+  { "name": "vrf", "terms": ["variable refrigerant flow"], "category": "Building Technologies" },
   {
     "name": "vrv-fan",
     "terms": ["variable refrigerant volume ventilator"],
@@ -3704,36 +1514,13 @@
     "terms": ["variable refrigerant volume swing"],
     "category": "Building Technologies"
   },
-  {
-    "name": "silent",
-    "terms": ["mute"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "smoking",
-    "terms": ["cigarette", "vaping"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "elevator",
-    "terms": ["lift"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "escalator",
-    "terms": ["moving stairs"],
-    "category": "Building Technologies"
-  },
+  { "name": "silent", "terms": ["mute"], "category": "Building Technologies" },
+  { "name": "smoking", "terms": ["cigarette", "vaping"], "category": "Building Technologies" },
+  { "name": "elevator", "terms": ["lift"], "category": "Building Technologies" },
+  { "name": "escalator", "terms": ["moving stairs"], "category": "Building Technologies" },
   { "name": "stair", "terms": ["steps", "staircase"], "category": "Building Technologies" },
-  {
-    "name": "database",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "data-quality",
-    "terms": ["data accuracy"],
-    "category": "Building Technologies"
-  },
+  { "name": "database", "category": "Building Technologies" },
+  { "name": "data-quality", "terms": ["data accuracy"], "category": "Building Technologies" },
   {
     "name": "set",
     "terms": ["collection", "group", "assortment"],
@@ -3769,51 +1556,20 @@
     "terms": ["delegated", "allocated", "designated"],
     "category": "Building Technologies"
   },
-  {
-    "name": "access-card",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "welcome",
-    "terms": ["greeting", "hand shake"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "qr-code",
-    "terms": ["quick response code"],
-    "category": "Building Technologies"
-  },
+  { "name": "access-card", "category": "Building Technologies" },
+  { "name": "welcome", "terms": ["greeting", "hand shake"], "category": "Building Technologies" },
+  { "name": "qr-code", "terms": ["quick response code"], "category": "Building Technologies" },
   {
     "name": "scan-qr-code",
     "terms": ["scan quick response code"],
     "category": "Building Technologies"
   },
-  {
-    "name": "scope",
-    "terms": ["topic"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "air-filter",
-    "terms": ["air refiner"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "factory",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "production-line",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "industrial-robot",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "electrolysis",
-    "category": "Building Technologies"
-  },
+  { "name": "scope", "terms": ["topic"], "category": "Building Technologies" },
+  { "name": "air-filter", "terms": ["air refiner"], "category": "Building Technologies" },
+  { "name": "factory", "category": "Building Technologies" },
+  { "name": "production-line", "category": "Building Technologies" },
+  { "name": "industrial-robot", "category": "Building Technologies" },
+  { "name": "electrolysis", "category": "Building Technologies" },
   {
     "name": "utilities",
     "terms": ["electricity", "gas", "sewage water"],
@@ -3846,15 +1602,8 @@
     "terms": ["region", "space", "section"],
     "category": "Building Technologies"
   },
-  {
-    "name": "area",
-    "terms": ["section"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "zone",
-    "category": "Building Technologies"
-  },
+  { "name": "area", "terms": ["section"], "category": "Building Technologies" },
+  { "name": "zone", "category": "Building Technologies" },
   {
     "name": "sub-area",
     "terms": ["region", "zone", "section", "district", "segment"],
@@ -3889,38 +1638,14 @@
     "terms": ["kind", "category", "class", "group", "sort"],
     "category": "Building Technologies"
   },
-  {
-    "name": "application-function",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "calculated-value",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "config-value",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "process-value",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "control-loop",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "trigger-value",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "physical-input",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "physical-output",
-    "category": "Building Technologies"
-  },
+  { "name": "application-function", "category": "Building Technologies" },
+  { "name": "calculated-value", "category": "Building Technologies" },
+  { "name": "config-value", "category": "Building Technologies" },
+  { "name": "process-value", "category": "Building Technologies" },
+  { "name": "control-loop", "category": "Building Technologies" },
+  { "name": "trigger-value", "category": "Building Technologies" },
+  { "name": "physical-input", "category": "Building Technologies" },
+  { "name": "physical-output", "category": "Building Technologies" },
   {
     "name": "collection",
     "terms": ["compilation", "assortment", "set", "series"],
@@ -3936,57 +1661,21 @@
     "terms": ["applications", "softwares", "programs"],
     "category": "Building Technologies"
   },
-  {
-    "name": "assets",
-    "terms": ["resources"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "wave",
-    "terms": ["hand", "gesture"],
-    "category": "Building Technologies"
-  },
+  { "name": "assets", "terms": ["resources"], "category": "Building Technologies" },
+  { "name": "wave", "terms": ["hand", "gesture"], "category": "Building Technologies" },
   {
     "name": "relationship",
     "terms": ["linkage", "connection"],
     "category": "Building Technologies"
   },
-  {
-    "name": "function",
-    "terms": ["operator"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "sum",
-    "terms": ["addition"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "project-filled",
-    "terms": ["plan"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "building-filled",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "floor-filled",
-    "terms": ["level"],
-    "category": "Building Technologies"
-  },
-  {
-    "name": "actuator-filled",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "automation-station-filled",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "valve-filled",
-    "category": "Building Technologies"
-  },
+  { "name": "function", "terms": ["operator"], "category": "Building Technologies" },
+  { "name": "sum", "terms": ["addition"], "category": "Building Technologies" },
+  { "name": "project-filled", "terms": ["plan"], "category": "Building Technologies" },
+  { "name": "building-filled", "category": "Building Technologies" },
+  { "name": "floor-filled", "terms": ["level"], "category": "Building Technologies" },
+  { "name": "actuator-filled", "category": "Building Technologies" },
+  { "name": "automation-station-filled", "category": "Building Technologies" },
+  { "name": "valve-filled", "category": "Building Technologies" },
   {
     "name": "group-lead-filled",
     "terms": [
@@ -4016,24 +1705,14 @@
     "terms": ["variable refrigerant flow"],
     "category": "Building Technologies"
   },
-  {
-    "name": "access-card-filled",
-    "category": "Building Technologies"
-  },
-  {
-    "name": "discovered-filled",
-    "category": "Building Technologies"
-  },
+  { "name": "access-card-filled", "category": "Building Technologies" },
+  { "name": "discovered-filled", "category": "Building Technologies" },
   {
     "name": "set-filled",
     "terms": ["collection", "group", "assortment"],
     "category": "Building Technologies"
   },
-  {
-    "name": "assets-filled",
-    "terms": ["resources"],
-    "category": "Building Technologies"
-  },
+  { "name": "assets-filled", "terms": ["resources"], "category": "Building Technologies" },
   {
     "name": "engineered-filled",
     "terms": ["constructed", "designed", "arranged"],
@@ -4044,66 +1723,19 @@
     "terms": ["vdu", "visual display unit", "monitor", "console"],
     "category": "Device"
   },
-  {
-    "name": "laptop",
-    "terms": ["notebook", "portable computer"],
-    "category": "Device"
-  },
-  {
-    "name": "controller",
-    "terms": ["remote control"],
-    "category": "Device"
-  },
-  {
-    "name": "room-unit",
-    "category": "Device"
-  },
-  {
-    "name": "touchpanel",
-    "terms": ["touchscreen", "touch display"],
-    "category": "Device"
-  },
-  {
-    "name": "tablet",
-    "terms": ["pad"],
-    "category": "Device"
-  },
-  {
-    "name": "smartphone",
-    "terms": ["mobile", "handy"],
-    "category": "Device"
-  },
+  { "name": "laptop", "terms": ["notebook", "portable computer"], "category": "Device" },
+  { "name": "controller", "terms": ["remote control"], "category": "Device" },
+  { "name": "room-unit", "category": "Device" },
+  { "name": "touchpanel", "terms": ["touchscreen", "touch display"], "category": "Device" },
+  { "name": "tablet", "terms": ["pad"], "category": "Device" },
+  { "name": "smartphone", "terms": ["mobile", "handy"], "category": "Device" },
   { "name": "smartphone-checked", "terms": ["mobile", "handy"], "category": "Device" },
-  {
-    "name": "landscape-to-portrait",
-    "terms": ["horizontal to vertical"],
-    "category": "Device"
-  },
-  {
-    "name": "portrait-to-landscape",
-    "terms": ["vertical to horizontal"],
-    "category": "Device"
-  },
-  {
-    "name": "mobile-commissioning",
-    "terms": ["setup", "nfc"],
-    "category": "Device"
-  },
-  {
-    "name": "wearable",
-    "terms": ["watch", "portable"],
-    "category": "Device"
-  },
-  {
-    "name": "device",
-    "terms": ["tool", "gadget", "appliance"],
-    "category": "Device"
-  },
-  {
-    "name": "device-alt",
-    "terms": ["tool", "gadget", "appliance"],
-    "category": "Device"
-  },
+  { "name": "landscape-to-portrait", "terms": ["horizontal to vertical"], "category": "Device" },
+  { "name": "portrait-to-landscape", "terms": ["vertical to horizontal"], "category": "Device" },
+  { "name": "mobile-commissioning", "terms": ["setup", "nfc"], "category": "Device" },
+  { "name": "wearable", "terms": ["watch", "portable"], "category": "Device" },
+  { "name": "device", "terms": ["tool", "gadget", "appliance"], "category": "Device" },
+  { "name": "device-alt", "terms": ["tool", "gadget", "appliance"], "category": "Device" },
   {
     "name": "face-very-happy",
     "terms": ["very good", "content", "pleased", "satisfied", "reaction", "emotions", "feelings"],
@@ -4240,11 +1872,7 @@
     "terms": ["development", "progression", "growth"],
     "category": "Composite States"
   },
-  {
-    "name": "state-pause",
-    "terms": ["stop", "break", "halt"],
-    "category": "Composite States"
-  },
+  { "name": "state-pause", "terms": ["stop", "break", "halt"], "category": "Composite States" },
   {
     "name": "state-face-very-happy",
     "terms": ["very good", "content", "pleased", "satisfied", "reaction", "emotions", "feelings"],
@@ -4293,64 +1921,19 @@
     ],
     "category": "Composite States"
   },
-  {
-    "name": "circle-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "square-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "triangle-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "square-45-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "octagon-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "shield-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "cloud-filled",
-    "category": "Composite States"
-  },
-  {
-    "name": "house-filled",
-    "terms": ["home"],
-    "category": "Composite States"
-  },
-  {
-    "name": "validation-success",
-    "terms": ["approval", "confirmation"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-issue",
-    "terms": ["error", "problem"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-critical",
-    "terms": ["problematic"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-warning",
-    "terms": ["danger"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-caution",
-    "terms": ["danger"],
-    "category": "Validation"
-  },
+  { "name": "circle-filled", "category": "Composite States" },
+  { "name": "square-filled", "category": "Composite States" },
+  { "name": "triangle-filled", "category": "Composite States" },
+  { "name": "square-45-filled", "category": "Composite States" },
+  { "name": "octagon-filled", "category": "Composite States" },
+  { "name": "shield-filled", "category": "Composite States" },
+  { "name": "cloud-filled", "category": "Composite States" },
+  { "name": "house-filled", "terms": ["home"], "category": "Composite States" },
+  { "name": "validation-success", "terms": ["approval", "confirmation"], "category": "Validation" },
+  { "name": "validation-issue", "terms": ["error", "problem"], "category": "Validation" },
+  { "name": "validation-critical", "terms": ["problematic"], "category": "Validation" },
+  { "name": "validation-warning", "terms": ["danger"], "category": "Validation" },
+  { "name": "validation-caution", "terms": ["danger"], "category": "Validation" },
   {
     "name": "validation-information",
     "terms": ["details", "description", "explanation"],
@@ -4366,26 +1949,10 @@
     "terms": ["approval", "confirmation"],
     "category": "Validation"
   },
-  {
-    "name": "validation-issue-filled",
-    "terms": ["error", "problem"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-critical-filled",
-    "terms": ["problematic"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-warning-filled",
-    "terms": ["danger"],
-    "category": "Validation"
-  },
-  {
-    "name": "validation-caution-filled",
-    "terms": ["danger"],
-    "category": "Validation"
-  },
+  { "name": "validation-issue-filled", "terms": ["error", "problem"], "category": "Validation" },
+  { "name": "validation-critical-filled", "terms": ["problematic"], "category": "Validation" },
+  { "name": "validation-warning-filled", "terms": ["danger"], "category": "Validation" },
+  { "name": "validation-caution-filled", "terms": ["danger"], "category": "Validation" },
   {
     "name": "validation-information-filled",
     "terms": ["details", "description", "explanation"],
@@ -4396,61 +1963,17 @@
     "terms": ["support", "guidance", "aid"],
     "category": "Validation"
   },
-  {
-    "name": "layout-fullscreen",
-    "terms": ["big screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-vertical",
-    "terms": ["portrait"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-horizontal",
-    "terms": ["landscape"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-1",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-2",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-2-right",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-3",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-3-alt",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-4",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-4-bottom",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-pane-5",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
+  { "name": "layout-fullscreen", "terms": ["big screen"], "category": "Screen Layout" },
+  { "name": "layout-vertical", "terms": ["portrait"], "category": "Screen Layout" },
+  { "name": "layout-horizontal", "terms": ["landscape"], "category": "Screen Layout" },
+  { "name": "layout-pane-1", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-2", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-2-right", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-3", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-3-alt", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-4", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-4-bottom", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-pane-5", "terms": ["canvas", "screen"], "category": "Screen Layout" },
   {
     "name": "layout-statusbar-small",
     "terms": ["canvas", "screen", "taskbar"],
@@ -4461,36 +1984,16 @@
     "terms": ["canvas", "screen", "taskbar"],
     "category": "Screen Layout"
   },
-  {
-    "name": "layout-send-to-primary",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
+  { "name": "layout-send-to-primary", "terms": ["canvas", "screen"], "category": "Screen Layout" },
   {
     "name": "layout-send-to-secondary",
     "terms": ["canvas", "screen"],
     "category": "Screen Layout"
   },
-  {
-    "name": "layout-send-to-manual",
-    "terms": ["canvas", "screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-fullscreen-filled",
-    "terms": ["big screen"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-vertical-filled",
-    "terms": ["portrait"],
-    "category": "Screen Layout"
-  },
-  {
-    "name": "layout-horizontal-filled",
-    "terms": ["landscape"],
-    "category": "Screen Layout"
-  },
+  { "name": "layout-send-to-manual", "terms": ["canvas", "screen"], "category": "Screen Layout" },
+  { "name": "layout-fullscreen-filled", "terms": ["big screen"], "category": "Screen Layout" },
+  { "name": "layout-vertical-filled", "terms": ["portrait"], "category": "Screen Layout" },
+  { "name": "layout-horizontal-filled", "terms": ["landscape"], "category": "Screen Layout" },
   {
     "name": "layout-send-to-primary-filled",
     "terms": ["canvas", "screen"],
@@ -4506,38 +2009,17 @@
     "terms": ["cardiac monitor", "electrocardiogram", "ecg"],
     "category": "Healthcare"
   },
-  {
-    "name": "hospital-bed",
-    "category": "Healthcare"
-  },
-  {
-    "name": "ultrasound-scanner",
-    "terms": ["sonogram", "echography"],
-    "category": "Healthcare"
-  },
-  {
-    "name": "wheelchair",
-    "terms": ["mobility aid"],
-    "category": "Healthcare"
-  },
-  {
-    "name": "accessible",
-    "terms": ["disability", "impairment"],
-    "category": "Healthcare"
-  },
-  {
-    "name": "stethoscope",
-    "category": "Healthcare"
-  },
+  { "name": "hospital-bed", "category": "Healthcare" },
+  { "name": "ultrasound-scanner", "terms": ["sonogram", "echography"], "category": "Healthcare" },
+  { "name": "wheelchair", "terms": ["mobility aid"], "category": "Healthcare" },
+  { "name": "accessible", "terms": ["disability", "impairment"], "category": "Healthcare" },
+  { "name": "stethoscope", "category": "Healthcare" },
   {
     "name": "surgical-mask",
     "terms": ["face mask", "hygiene mask", "medical mask"],
     "category": "Healthcare"
   },
-  {
-    "name": "medical-gas",
-    "category": "Healthcare"
-  },
+  { "name": "medical-gas", "category": "Healthcare" },
   { "name": "first-aid", "category": "Healthcare" },
   { "name": "first-responder", "category": "Healthcare" },
   {
@@ -4556,89 +2038,33 @@
     "terms": ["cardiac defibrillator", "heart defibrillator"],
     "category": "Healthcare"
   },
-  {
-    "name": "3d-fit",
-    "category": "3D"
-  },
-  {
-    "name": "3d-rotate",
-    "category": "3D"
-  },
-  {
-    "name": "3d-y-axis",
-    "category": "3D"
-  },
-  {
-    "name": "3d-z-axis",
-    "category": "3D"
-  },
-  {
-    "name": "3d-front",
-    "category": "3D"
-  },
-  {
-    "name": "3d-back",
-    "category": "3D"
-  },
-  {
-    "name": "3d-top",
-    "category": "3D"
-  },
-  {
-    "name": "3d-bottom",
-    "category": "3D"
-  },
-  {
-    "name": "3d-left",
-    "category": "3D"
-  },
-  {
-    "name": "3d-right",
-    "category": "3D"
-  },
-  {
-    "name": "emergency-phone",
-    "terms": ["sos", "distress call"],
-    "category": "Pharma"
-  },
-  {
-    "name": "escape-left",
-    "terms": ["exit left"],
-    "category": "Pharma"
-  },
-  {
-    "name": "escape-right",
-    "terms": ["exit right"],
-    "category": "Pharma"
-  },
-  {
-    "name": "radioactive",
-    "category": "Pharma"
-  },
+  { "name": "3d-fit", "category": "3D" },
+  { "name": "3d-rotate", "category": "3D" },
+  { "name": "3d-y-axis", "category": "3D" },
+  { "name": "3d-z-axis", "category": "3D" },
+  { "name": "3d-front", "category": "3D" },
+  { "name": "3d-back", "category": "3D" },
+  { "name": "3d-top", "category": "3D" },
+  { "name": "3d-bottom", "category": "3D" },
+  { "name": "3d-left", "category": "3D" },
+  { "name": "3d-right", "category": "3D" },
+  { "name": "emergency-phone", "terms": ["sos", "distress call"], "category": "Pharma" },
+  { "name": "escape-left", "terms": ["exit left"], "category": "Pharma" },
+  { "name": "escape-right", "terms": ["exit right"], "category": "Pharma" },
+  { "name": "radioactive", "category": "Pharma" },
   {
     "name": "biological-hazard",
     "terms": ["health hazard", "biological threat", "biological risk"],
     "category": "Pharma"
   },
-  {
-    "name": "explosive-atmosphere",
-    "terms": ["flammable atmosphere"],
-    "category": "Pharma"
-  },
-  {
-    "name": "gas-bottles",
-    "category": "Pharma"
-  },
+  { "name": "explosive-atmosphere", "terms": ["flammable atmosphere"], "category": "Pharma" },
+  { "name": "gas-bottles", "category": "Pharma" },
   {
     "name": "respiratory",
     "terms": ["breathing", "inhalation", "ventilatory"],
     "category": "Pharma"
   },
-  {
-    "name": "eye-protection",
-    "terms": ["glasses", "safety goggles"],
-    "category": "Pharma"
-  },
+  { "name": "eye-protection", "terms": ["glasses", "safety goggles"], "category": "Pharma" },
   {
     "name": "breathing-protection",
     "terms": ["respiratory protection", "lung protection"],


### PR DESCRIPTION
build(lint-metadat): fix mode + remove inner-source icons

When syncing our inner source repo with the open source one,
we want to remove all inner source icons.
With these changes, we allow to just copy the entire
svg icons directory and the metadata file.
Then the script will remove all inner source icons.

@fh1ch the metadata file is re-formatted on purpose. The fix mode removes all line breaks, and prettier only re-adds them when needed. So we have less line-breaks than before.